### PR TITLE
Difficulty scaling overhaul, Insane mode, DoT/beam bug fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 ## 2026-03-18
 
+### Difficulty Scaling Overhaul
+- **Quadratic HP scaling**: Creep HP now scales as `20 + wave*8 + wave²*0.4`. Waves 1-10 feel nearly the same, but wave 20+ creeps have roughly double the old HP (340 vs 180 at wave 20, 620 vs 260 at wave 30). Late game is no longer trivially won.
+- **Late-wave themed compositions**: Waves 21+ now have synergistic themes instead of "everything at once" — healer+armored packs (21-22), speed+swarm rushes (23-24), shielded+regen DPS checks (25-26), flying+evasion maze bypasses (27-28), and full mixed chaos (29+).
+- **Kill gold decay**: Kill gold decreases by 1 per 10 waves (5g→4g→3g→2g floor). Prevents infinite income snowball in late waves.
+- **Hard difficulty tuned up**: Toughness 1.5→2.0, count 1.4→1.6, speed 1.15→1.2, gold mult 0.75→0.6. Hard mode wave 25+ is now genuinely punishing.
+- **New Insane difficulty**: Toughness 3.5×, count 2.0×, speed 1.35×, gold 0.4×. Probably not winnable. Bosses get damage-cap shields (40 hits). Armored creeps regenerate. Evasive creeps dodge 45%. Shielded creeps have 40-hit shields. Regenerators heal 5%/s. Good luck.
+- **Faster late spawns**: Spawn interval floor lowered from 200ms to 150ms, scaling steeper (wave 30: 240ms vs old 300ms).
+
+### New Creep Type: Regenerator
+- **Regenerator**: Heavy armor, 1.8× HP, 0.85× speed, regenerates 2% max HP/s. Appears in waves 25+. On hard mode (toughness ≥ 2.0), regen increases to 3%. Forces sustained DPS rather than burst.
+- **Boss regen on hard**: Hard-mode bosses gain 1% HP/s regeneration, making them much more threatening.
+- New `regeneration` creep trait with green pulse visual effect when healing.
+
+### Bug Fix: DoT/Beam Rounding
+- **Fixed zero-damage DoTs**: At 60fps, per-frame DoT damage (e.g. Virus 10 DPS × 0.016s = 0.16) was rounded to 0 by `Math.round()`. Added accumulator pattern — fractional damage carries between frames, only applied when ≥1 HP. Virus, burn, and poison effects now deal correct damage.
+- **Fixed Firewall beam zero damage**: Same rounding bug caused `Math.round(20 * 0.016) = 0`. Removed rounding — beam now applies raw float damage. HP checks (`<= 0`) work fine with floats.
+
 ### Responsive Scaling & Tablet Support
 - **Dynamic grid offset**: `GRID_OFFSET_X` and `CANVAS_WIDTH` are now dynamic functions (`getGridOffsetX()`, `getCanvasWidth()`) that read from `ResponsiveManager`. On desktop (window >= 1200px), layout is unchanged. On tablet, grid offset is 0 and canvas shrinks to game area only.
 - **ResponsiveManager** (`src/systems/ResponsiveManager.ts`): Singleton that detects layout mode from `window.innerWidth`, fires resize events, exposes `isTablet()`, `canvasWidth()`, `gridOffsetX()`.

--- a/GAMEMODES.md
+++ b/GAMEMODES.md
@@ -15,10 +15,11 @@ Quick game with fewer creep types. Good for learning tower synergies and testing
 
 The core experience. All creep types appear progressively. Full economic depth.
 
-- **Waves**: 30. Boss every 10th wave. Mages from wave 18, flying from wave 19.
-- **Economy**: Standard gold. Kills + wave income + frontier.
+- **Waves**: 30. Boss every 10th wave. Mages from wave 18, flying from wave 19. Regenerators from wave 25. Late waves (21+) have themed synergistic compositions.
+- **Economy**: Standard gold. Kills + wave income + frontier. Kill gold decays by 1 per 10 waves (5g→4g→3g→2g floor).
 - **Sends**: Available. Income bonus compounds over 30 waves.
 - **Frontier**: Faction-specific buildings with overcharge/dig/harvest actions.
+- **Difficulty scaling**: HP scales quadratically — waves 1-10 feel familiar, but wave 20+ creeps are significantly tougher. Hard mode is genuinely punishing. Insane mode is probably not winnable.
 - **Win condition**: Survive all 30 waves.
 
 ### Strategy Tips
@@ -26,6 +27,8 @@ The core experience. All creep types appear progressively. Full economic depth.
 - Invest in frontier buildings early for compound income.
 - Save sends for after wave 10 when income matters most.
 - Build a maze before bosses at waves 10, 20, 30.
+- Waves 25-26 bring regenerators — you need sustained DPS, not burst.
+- Hard mode bosses regenerate HP. You need overwhelming firepower.
 
 ---
 
@@ -33,7 +36,7 @@ The core experience. All creep types appear progressively. Full economic depth.
 
 Infinite scaling. How far can you go?
 
-- **Waves**: 100+ (generated). All creep types from wave 20+. HP and speed scale continuously.
+- **Waves**: 100+ (generated). All creep types from wave 20+, regenerators from 25+. HP scales quadratically, speed scales continuously.
 - **Economy**: Standard gold. Same as Standard but the income window is much longer.
 - **Win condition**: None — play until you lose. Score based on wave reached.
 

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Standard, Fast, Armored, Swarm, Healer, Boss, Group, Splitter, Shielded, Evasive
 - **Frontier** — Invest in passive income buildings with faction-flavored mechanics
 
 ### Difficulty System
-Easy/Normal/Hard. Each creep type interprets difficulty individually — armored gets tankier, swarms multiply, fast creeps get faster.
+Easy/Normal/Hard/Insane. Each creep type interprets difficulty individually — armored gets tankier, swarms multiply, fast creeps get faster. Insane mode adds extra traits (boss damage-cap shields, armored regen, 45% evasion) and is probably not winnable.
 
 ### Multiplayer (P2P WebRTC)
 - No server required — manual SDP exchange via clipboard

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ npm run dev
 
 ## Game Overview
 
-Build towers to create mazes, defend against 14 creep types across 30+ waves, manage your economy across three channels (towers, sends, frontier), and leverage your faction's unique strengths. Play solo or versus a friend via peer-to-peer WebRTC.
+Build towers to create mazes, defend against 15 creep types across 30+ waves, manage your economy across three channels (towers, sends, frontier), and leverage your faction's unique strengths. Play solo or versus a friend via peer-to-peer WebRTC.
 
 ### Match Flow
 1. **Menu** — Choose map, difficulty, match mode, or multiplayer (Versus 1v1 / Circle Co-op)

--- a/src/data/CreepTypes.ts
+++ b/src/data/CreepTypes.ts
@@ -82,7 +82,9 @@ export const CREEP_TYPES: Record<string, CreepType> = {
         speedMult: hints.speed * 0.9, // barely speeds up
         countMult: Math.max(1, hints.count * 0.6), // fewer extras — each one is a problem
         goldMult: hints.goldMult,
-        extraTraits: [],
+        extraTraits: hints.toughness >= 3.0
+          ? [{ id: 'regeneration', regenPercent: 0.01 }] // insane: armored also regen
+          : [],
       };
     },
   },
@@ -132,9 +134,11 @@ export const CREEP_TYPES: Record<string, CreepType> = {
         speedMult: hints.speed * 0.95,
         countMult: 1, // always exactly 1 boss
         goldMult: hints.goldMult,
-        extraTraits: hints.toughness >= 1.5
-          ? [{ id: 'shield', hpPercent: 0.5 }] // harder difficulty = bigger shield
-          : [],
+        extraTraits: [
+          ...(hints.toughness >= 1.5 ? [{ id: 'shield', hpPercent: 0.5 }] : []),
+          ...(hints.toughness >= 2.0 ? [{ id: 'regeneration', regenPercent: 0.01 }] : []),
+          ...(hints.toughness >= 3.0 ? [{ id: 'damage_cap_shield', shieldHits: 40 }] : []),
+        ],
       };
     },
   },
@@ -259,9 +263,11 @@ export const CREEP_TYPES: Record<string, CreepType> = {
         speedMult: hints.speed,
         countMult: Math.max(1, hints.count * 0.7),
         goldMult: hints.goldMult,
-        extraTraits: hints.toughness >= 1.5
-          ? [{ id: 'damage_cap_shield', shieldHits: 25 }]
-          : [],
+        extraTraits: hints.toughness >= 3.0
+          ? [{ id: 'damage_cap_shield', shieldHits: 40 }] // insane: absurd shield
+          : hints.toughness >= 1.5
+            ? [{ id: 'damage_cap_shield', shieldHits: 25 }]
+            : [],
       };
     },
   },
@@ -278,9 +284,32 @@ export const CREEP_TYPES: Record<string, CreepType> = {
         speedMult: hints.speed * 1.1,
         countMult: hints.count,
         goldMult: hints.goldMult,
-        extraTraits: hints.toughness >= 1.5
-          ? [{ id: 'evasion', chance: 0.35 }] // harder = more evasion
-          : [],
+        extraTraits: hints.toughness >= 3.0
+          ? [{ id: 'evasion', chance: 0.45 }] // insane: nearly half dodged
+          : hints.toughness >= 1.5
+            ? [{ id: 'evasion', chance: 0.35 }]
+            : [],
+      };
+    },
+  },
+
+  regenerator: {
+    id: 'regenerator', name: 'Regenerator', description: 'Heavy armor, regenerates 2% max HP/s. DPS check.',
+    hpMultiplier: 1.8, speedMultiplier: 0.85, armor: 'heavy',
+    color: 0x22cc44, size: 1.15, count: 1,
+    traits: [{ id: 'regeneration', regenPercent: 0.02 }],
+    spawnBehavior: 'normal',
+    applyDifficulty(hints) {
+      return {
+        hpMult: hints.toughness * 1.2,
+        speedMult: hints.speed * 0.95,
+        countMult: Math.max(1, hints.count * 0.7),
+        goldMult: hints.goldMult,
+        extraTraits: hints.toughness >= 3.0
+          ? [{ id: 'regeneration', regenPercent: 0.05 }] // insane = 5% regen
+          : hints.toughness >= 2.0
+            ? [{ id: 'regeneration', regenPercent: 0.03 }] // hard = 3% regen
+            : [],
       };
     },
   },

--- a/src/data/Difficulty.ts
+++ b/src/data/Difficulty.ts
@@ -9,7 +9,7 @@ export interface DifficultyHints {
   goldMult: number;   // 1.0 = normal, 0.8 = 20% less gold
 }
 
-export type DifficultyLevel = 'easy' | 'normal' | 'hard';
+export type DifficultyLevel = 'easy' | 'normal' | 'hard' | 'insane';
 
 export const DIFFICULTIES: Record<DifficultyLevel, DifficultyHints> = {
   easy: {
@@ -25,9 +25,15 @@ export const DIFFICULTIES: Record<DifficultyLevel, DifficultyHints> = {
     goldMult: 1.0,
   },
   hard: {
-    toughness: 1.5,
-    count: 1.4,
-    speed: 1.15,
-    goldMult: 0.75,
+    toughness: 2.0,
+    count: 1.6,
+    speed: 1.2,
+    goldMult: 0.6,
+  },
+  insane: {
+    toughness: 3.5,
+    count: 2.0,
+    speed: 1.35,
+    goldMult: 0.4,
   },
 };

--- a/src/data/Lore.ts
+++ b/src/data/Lore.ts
@@ -125,5 +125,6 @@ export const CREEP_LORE: Record<string, string> = {
   mage_evasion: 'Grants nearby creeps a chance to dodge attacks entirely. Extremely frustrating.',
   mage_heal: 'Periodically heals nearby creeps for a flat amount. Sustained, reliable, dangerous.',
   evasive: 'One in four attacks simply misses. High fire-rate towers improve the odds.',
+  regenerator: 'Thick-skinned and self-healing. Chip damage means nothing — you need sustained, overwhelming firepower.',
   flying: 'Ignores your carefully constructed maze. Flies in a straight line to the exit. Plan accordingly.',
 };

--- a/src/data/WaveDefinitions.ts
+++ b/src/data/WaveDefinitions.ts
@@ -19,9 +19,9 @@ function generateStandardWaves(count: number): WaveDefinition[] {
 
   for (let i = 0; i < count; i++) {
     const waveNum = i + 1;
-    const baseHp = 20 + waveNum * 8;
+    const baseHp = Math.round(20 + waveNum * 8 + waveNum * waveNum * 0.4);
     const baseSpeed = 1 + waveNum * 0.02;
-    const interval = Math.max(200, 600 - waveNum * 10);
+    const interval = Math.max(150, 600 - waveNum * 12);
 
     // Boss waves every 10
     if (waveNum % 10 === 0) {
@@ -84,20 +84,51 @@ function generateStandardWaves(count: number): WaveDefinition[] {
       if (waveNum >= 19) {
         groups.push({ creepType: 'flying', count: 2, hpScale: baseHp, speedScale: baseSpeed });
       }
-    } else {
-      // Late game: everything
+    } else if (waveNum <= 22) {
+      // Wave 21-22: Healer + Armored packs (healers keep tanks alive)
+      groups.push({ creepType: 'armored', count: 6, hpScale: baseHp, speedScale: baseSpeed });
+      groups.push({ creepType: 'healer', count: 2, hpScale: baseHp, speedScale: baseSpeed });
       groups.push({ creepType: 'standard', count: Math.floor(waveNum * 0.4), hpScale: baseHp, speedScale: baseSpeed });
+      groups.push({ creepType: 'shielded', count: 2, hpScale: baseHp, speedScale: baseSpeed });
+      groups.push({ creepType: 'mage_armor', count: 1, hpScale: baseHp, speedScale: baseSpeed });
+      groups.push({ creepType: 'mage_heal', count: 1, hpScale: baseHp, speedScale: baseSpeed });
+    } else if (waveNum <= 24) {
+      // Wave 23-24: Speed + Swarm rush (overwhelming numbers)
+      groups.push({ creepType: 'fast', count: 8, hpScale: baseHp, speedScale: baseSpeed });
+      groups.push({ creepType: 'swarm', count: 6, hpScale: baseHp, speedScale: baseSpeed });
+      groups.push({ creepType: 'evasive', count: 4, hpScale: baseHp, speedScale: baseSpeed });
+      groups.push({ creepType: 'mage_speed', count: 1, hpScale: baseHp, speedScale: baseSpeed });
+      groups.push({ creepType: 'group', count: 3, hpScale: baseHp, speedScale: baseSpeed });
+    } else if (waveNum <= 26) {
+      // Wave 25-26: Shielded + Heal + Regenerator (DPS check)
+      groups.push({ creepType: 'shielded', count: 4, hpScale: baseHp, speedScale: baseSpeed });
+      groups.push({ creepType: 'regenerator', count: 3, hpScale: baseHp, speedScale: baseSpeed });
+      groups.push({ creepType: 'healer', count: 2, hpScale: baseHp, speedScale: baseSpeed });
+      groups.push({ creepType: 'mage_heal', count: 1, hpScale: baseHp, speedScale: baseSpeed });
+      groups.push({ creepType: 'armored', count: 3, hpScale: baseHp, speedScale: baseSpeed });
+      groups.push({ creepType: 'splitter', count: 2, hpScale: baseHp, speedScale: baseSpeed });
+    } else if (waveNum <= 28) {
+      // Wave 27-28: Flying + Healer + Evasion (bypass maze + sustain)
+      groups.push({ creepType: 'flying', count: 5, hpScale: baseHp, speedScale: baseSpeed });
+      groups.push({ creepType: 'healer', count: 2, hpScale: baseHp, speedScale: baseSpeed });
+      groups.push({ creepType: 'evasive', count: 4, hpScale: baseHp, speedScale: baseSpeed });
+      groups.push({ creepType: 'mage_evasion', count: 1, hpScale: baseHp, speedScale: baseSpeed });
       groups.push({ creepType: 'fast', count: 5, hpScale: baseHp, speedScale: baseSpeed });
-      groups.push({ creepType: 'armored', count: 4, hpScale: baseHp, speedScale: baseSpeed });
-      groups.push({ creepType: 'swarm', count: 4, hpScale: baseHp, speedScale: baseSpeed });
+      groups.push({ creepType: 'regenerator', count: 2, hpScale: baseHp, speedScale: baseSpeed });
+    } else {
+      // Wave 29+: Everything mixed, maximum threat
+      groups.push({ creepType: 'armored', count: 5, hpScale: baseHp, speedScale: baseSpeed });
+      groups.push({ creepType: 'fast', count: 6, hpScale: baseHp, speedScale: baseSpeed });
+      groups.push({ creepType: 'swarm', count: 5, hpScale: baseHp, speedScale: baseSpeed });
+      groups.push({ creepType: 'shielded', count: 4, hpScale: baseHp, speedScale: baseSpeed });
+      groups.push({ creepType: 'regenerator', count: 3, hpScale: baseHp, speedScale: baseSpeed });
+      groups.push({ creepType: 'healer', count: 2, hpScale: baseHp, speedScale: baseSpeed });
+      groups.push({ creepType: 'flying', count: 4, hpScale: baseHp, speedScale: baseSpeed });
       groups.push({ creepType: 'evasive', count: 3, hpScale: baseHp, speedScale: baseSpeed });
       groups.push({ creepType: 'splitter', count: 2, hpScale: baseHp, speedScale: baseSpeed });
-      groups.push({ creepType: 'shielded', count: 3, hpScale: baseHp, speedScale: baseSpeed });
-      groups.push({ creepType: 'healer', count: 1, hpScale: baseHp, speedScale: baseSpeed });
       groups.push({ creepType: 'group', count: 3, hpScale: baseHp, speedScale: baseSpeed });
-      groups.push({ creepType: 'flying', count: 3, hpScale: baseHp, speedScale: baseSpeed });
       // Rotating mage
-      const mageTypes = ['mage_armor', 'mage_speed', 'mage_evasion'];
+      const mageTypes = ['mage_armor', 'mage_speed', 'mage_evasion', 'mage_heal'];
       groups.push({ creepType: mageTypes[waveNum % mageTypes.length], count: 1, hpScale: baseHp, speedScale: baseSpeed });
     }
 

--- a/src/scenes/ChangelogScene.ts
+++ b/src/scenes/ChangelogScene.ts
@@ -5,6 +5,22 @@ import { TowerSelectBar } from '../ui/TowerSelectBar';
 // In-app changelog — recent changes shown to the player
 const CHANGELOG_ENTRIES = [
   {
+    version: 'v19 — Difficulty Scaling & Bug Fixes',
+    changes: [
+      'Fixed DoT/beam rounding bug: Virus, burn, and Firewall beam were dealing 0 damage at 60fps',
+      'Quadratic HP scaling: late-wave creeps are much tougher (wave 20: 340 HP, wave 30: 620 HP)',
+      'Themed late-wave compositions: healer+tank packs, speed rushes, regen DPS checks, flying bypasses',
+      'Kill gold decays over time (5g → 4g → 3g → 2g floor) to prevent income snowball',
+      'New creep type: Regenerator — heavy armor, 2% HP/s regen, appears wave 25+',
+      'New regeneration trait with green pulse visual effect',
+      'Hard difficulty retuned: toughness 2.0×, count 1.6×, speed 1.2×, gold 0.6×',
+      'New Insane difficulty: 3.5× toughness, 2× count, 1.35× speed, 0.4× gold. Good luck.',
+      'Insane extras: boss damage-cap shields, armored regen, 45% evasion, 5% regenerator regen',
+      'Hard-mode bosses now regenerate 1% HP/s',
+      'Faster late-wave spawns (floor lowered to 150ms)',
+    ],
+  },
+  {
     version: 'v18 — Responsive Scaling & Tablet Support',
     changes: [
       'Tablet layout: sidebar becomes a collapsible overlay with hamburger toggle',
@@ -126,7 +142,7 @@ const CHANGELOG_ENTRIES = [
   {
     version: 'v9 — Creep Variety & Difficulty',
     changes: [
-      'Difficulty system: Easy/Normal/Hard with per-creep-type scaling',
+      'Difficulty system: Easy/Normal/Hard/Insane with per-creep-type scaling',
       '7 new creep types: Group, Splitter, Shielded, Evasive, Flying, 4 Mage types',
       'Flying creeps bypass maze entirely (straight line to exit)',
       'Shielded creeps: max 1 damage per hit until shield breaks',

--- a/src/scenes/CircleLobbyScene.ts
+++ b/src/scenes/CircleLobbyScene.ts
@@ -346,8 +346,8 @@ export class CircleLobbyScene extends Phaser.Scene {
       const diffLabel = this.add.text(cx, 248, 'Difficulty:', { fontSize: '13px', color: '#aaaaaa', fontFamily: 'monospace' }).setOrigin(0.5);
       this.dynamicElements.push(diffLabel);
 
-      const diffs: DifficultyLevel[] = ['easy', 'normal', 'hard'];
-      const diffColors: Record<string, string> = { easy: '#44ff44', normal: '#ffaa44', hard: '#ff4444' };
+      const diffs: DifficultyLevel[] = ['easy', 'normal', 'hard', 'insane'];
+      const diffColors: Record<string, string> = { easy: '#44ff44', normal: '#ffaa44', hard: '#ff4444', insane: '#ff00ff' };
       const diffBtns: { btn: Phaser.GameObjects.Text; id: DifficultyLevel }[] = [];
       for (let i = 0; i < diffs.length; i++) {
         const did = diffs[i];

--- a/src/scenes/EncyclopediaScene.ts
+++ b/src/scenes/EncyclopediaScene.ts
@@ -436,6 +436,7 @@ export class EncyclopediaScene extends Phaser.Scene {
           case 'evasion_aura': return `${Math.round((t.evasionBonus ?? 0.15) * 100)}% Evasion Aura`;
           case 'evasion': return `${Math.round((t.chance ?? 0.25) * 100)}% Evasion`;
           case 'split_on_death': return `Splits into ${t.splitCount}`;
+          case 'regeneration': return `Regen(${Math.round((t.regenPercent ?? 0.02) * 100)}%hp/s)`;
           default: return t.id;
         }
       }).join(', ') || 'None';

--- a/src/scenes/LobbyScene.ts
+++ b/src/scenes/LobbyScene.ts
@@ -186,8 +186,8 @@ export class LobbyScene extends Phaser.Scene {
 
       this.add.text(cx, 230, 'Difficulty:', { fontSize: '13px', color: '#aaaaaa', fontFamily: 'monospace' }).setOrigin(0.5);
 
-      const diffs: DifficultyLevel[] = ['easy', 'normal', 'hard'];
-      const diffColors: Record<string, string> = { easy: '#44ff44', normal: '#ffaa44', hard: '#ff4444' };
+      const diffs: DifficultyLevel[] = ['easy', 'normal', 'hard', 'insane'];
+      const diffColors: Record<string, string> = { easy: '#44ff44', normal: '#ffaa44', hard: '#ff4444', insane: '#ff00ff' };
       const diffBtns: { btn: Phaser.GameObjects.Text; id: DifficultyLevel }[] = [];
       const diffStartX = cx - (diffs.length * 80) / 2;
       for (let i = 0; i < diffs.length; i++) {

--- a/src/scenes/MenuScene.ts
+++ b/src/scenes/MenuScene.ts
@@ -75,6 +75,7 @@ export class MenuScene extends Phaser.Scene {
       { id: 'easy', label: 'Easy', color: '#44ff44' },
       { id: 'normal', label: 'Normal', color: '#ffaa44' },
       { id: 'hard', label: 'Hard', color: '#ff4444' },
+      { id: 'insane', label: 'Insane', color: '#ff00ff' },
     ];
     const diffBtnW = 90;
     const diffGap = 8;

--- a/src/systems/EconomyManager.ts
+++ b/src/systems/EconomyManager.ts
@@ -10,6 +10,7 @@ import { ResourceManager } from './ResourceManager';
 export class EconomyManager {
   resources: ResourceManager;
   private events: EventBus;
+  private currentWave = 0;
 
   constructor(events: EventBus, resourceMgr?: ResourceManager) {
     this.events = events;
@@ -32,6 +33,10 @@ export class EconomyManager {
 
     events.on('waveCleared', () => {
       this.addGold(WAVE_CLEAR_BONUS);
+    });
+
+    events.on('waveStarted', (waveNum: number) => {
+      this.currentWave = waveNum;
     });
   }
 
@@ -57,6 +62,6 @@ export class EconomyManager {
   }
 
   getKillGold(): number {
-    return KILL_GOLD;
+    return Math.max(2, KILL_GOLD - Math.floor(this.currentWave / 10));
   }
 }

--- a/src/systems/StatusEffects.ts
+++ b/src/systems/StatusEffects.ts
@@ -6,6 +6,7 @@ export interface StatusEffect {
 
 export class StatusEffectManager {
   effects: StatusEffect[] = [];
+  private _dotAccum = 0;
 
   apply(type: string, duration: number, magnitude: number): void {
     const existing = this.effects.find(e => e.type === type);
@@ -49,15 +50,16 @@ export class StatusEffectManager {
 
   /** Total DoT damage this frame (flat burn + % poison + virus) */
   getDotDamage(delta: number, maxHp: number): number {
-    let total = 0;
     for (const e of this.effects) {
       if (e.type === 'burn' || e.type === 'virus') {
-        total += e.magnitude * (delta / 1000);
+        this._dotAccum += e.magnitude * (delta / 1000);
       } else if (e.type === 'poison') {
-        total += maxHp * e.magnitude * (delta / 1000);
+        this._dotAccum += maxHp * e.magnitude * (delta / 1000);
       }
     }
-    return Math.round(total);
+    const dmg = Math.floor(this._dotAccum);
+    this._dotAccum -= dmg;
+    return dmg;
   }
 
   /** Is this creep confused (walking backward)? */

--- a/src/systems/traits/CreepTraitHandlers.ts
+++ b/src/systems/traits/CreepTraitHandlers.ts
@@ -165,6 +165,28 @@ registerCreepUpdate('evasion_aura', (trait: Trait, creep: any, _delta: number, n
 });
 
 // ============================================================
+// Regeneration — heals percentage of max HP per second
+// ============================================================
+
+registerCreepUpdate('regeneration', (trait: Trait, creep: any, delta: number, _nearbyCreeps: any[]) => {
+  if (!creep.alive || creep.reached) return;
+  if (creep.hp >= creep.maxHp) return;
+
+  const regenPercent = trait.regenPercent ?? 0.02;
+  const healAmount = creep.maxHp * regenPercent * (delta / 1000);
+  creep.hp = Math.min(creep.maxHp, creep.hp + healAmount);
+});
+
+registerCreepDraw('regeneration', (_trait: Trait, creep: any, g: any) => {
+  if (creep.hp >= creep.maxHp) return;
+  // Green pulse when regenerating
+  const pulse = 0.3 + 0.2 * Math.sin(Date.now() * 0.005);
+  const baseSize = creep.isBoss ? TILE_SIZE * 0.45 : TILE_SIZE * 0.3;
+  g.lineStyle(2, 0x44ff44, pulse);
+  g.strokeCircle(creep.x, creep.y, baseSize * creep.size + 3);
+});
+
+// ============================================================
 // Visual overlays
 // ============================================================
 

--- a/src/systems/traits/TowerTraitHandlers.ts
+++ b/src/systems/traits/TowerTraitHandlers.ts
@@ -658,8 +658,8 @@ registerTowerUpdate('firewall_link', (trait: Trait, tower: any, ctx: UpdateConte
     const perpY = cy - proj * ny;
     const perpDist = Math.sqrt(perpX * perpX + perpY * perpY);
     if (perpDist <= TILE_SIZE * 0.6) {
-      creep.takeDamage(Math.round(damage));
-      tower.damageDealt += Math.round(damage);
+      creep.takeDamage(damage);
+      tower.damageDealt += damage;
     }
   }
 


### PR DESCRIPTION
Fix zero-damage DoTs and firewall beam — per-frame damage was rounded to 0 at 60fps (e.g. 10 DPS × 0.016s = 0.16 → Math.round → 0). DoTs now use an accumulator that carries fractional damage between frames. Firewall beam passes raw float damage instead of rounding.

Overhaul late-game difficulty scaling:
- Quadratic HP formula (20 + wave*8 + wave²*0.4) — wave 20 HP nearly doubles from 180→340, wave 30 from 260→620
- Themed wave 21+ compositions with synergistic creep packs instead of flat "everything at once"
- Kill gold decays by 1 per 10 waves (5→4→3→2 floor)
- Faster late spawns (floor 200→150ms, steeper ramp)
- Hard difficulty tuned up (toughness 2.0, count 1.6, speed 1.2, gold 0.6)

Add Insane difficulty (toughness 3.5, count 2.0, speed 1.35, gold 0.4) with extra creep modifiers: boss damage-cap shields, armored regen, 45% evasion, 40-hit shields, 5% regenerator regen. Probably not winnable.

Add regenerator creep type (1.8× HP, heavy armor, 2% HP/s regen) and regeneration trait with green pulse visual. Appears wave 25+. Hard-mode bosses also gain 1% regen.