### PR TITLE
Send cost scaling and tier 2 sends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## 2026-03-18
 
+### Send Scaling & Tier 2 Sends
+- **Send cost scaling**: Send costs now increase +10% per 5 waves (rounded to nearest 5g). Income rewards also scale slightly (+0.5 per 10 waves) to compensate.
+- **Tier 2 sends**: 4 new send types that unlock as the game progresses:
+  - **Healer Pack** (70g, wave 10+): +2 healers that sustain nearby creeps
+  - **Shielded Pack** (80g, wave 10+): +2 shielded creeps (1 dmg/hit cap)
+  - **Flying Squad** (90g, wave 15+): +3 flying creeps that bypass the maze
+  - **Regen Pack** (100g, wave 20+): +2 regenerators with 2% HP/s regen
+- Send panel now shows locked tier 2 sends with unlock wave, and updates costs/availability each wave.
+- Hotkeys 1-4 mapped to tier 2 sends (Z/X/C/V remain for tier 1).
+
 ### Difficulty Scaling Overhaul
 - **Quadratic HP scaling**: Creep HP now scales as `20 + wave*8 + wave²*0.4`. Waves 1-10 feel nearly the same, but wave 20+ creeps have roughly double the old HP (340 vs 180 at wave 20, 620 vs 260 at wave 30). Late game is no longer trivially won.
 - **Late-wave themed compositions**: Waves 21+ now have synergistic themes instead of "everything at once" — healer+armored packs (21-22), speed+swarm rushes (23-24), shielded+regen DPS checks (25-26), flying+evasion maze bypasses (27-28), and full mixed chaos (29+).

--- a/GAMEMODES.md
+++ b/GAMEMODES.md
@@ -17,7 +17,7 @@ The core experience. All creep types appear progressively. Full economic depth.
 
 - **Waves**: 30. Boss every 10th wave. Mages from wave 18, flying from wave 19. Regenerators from wave 25. Late waves (21+) have themed synergistic compositions.
 - **Economy**: Standard gold. Kills + wave income + frontier. Kill gold decays by 1 per 10 waves (5g→4g→3g→2g floor).
-- **Sends**: Available. Income bonus compounds over 30 waves.
+- **Sends**: Available. Income bonus compounds over 30 waves. Costs scale +10% per 5 waves. Tier 2 sends (healer, shielded, flying, regen) unlock at waves 10/15/20.
 - **Frontier**: Faction-specific buildings with overcharge/dig/harvest actions.
 - **Difficulty scaling**: HP scales quadratically — waves 1-10 feel familiar, but wave 20+ creeps are significantly tougher. Hard mode is genuinely punishing. Insane mode is probably not winnable.
 - **Win condition**: Survive all 30 waves.

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Build towers to create mazes, defend against 15 creep types across 30+ waves, ma
 | Left click (grid) | Build / Inspect tower / Inspect creep |
 | Right click / Long-press | Sell tower |
 | Z/X/C/V | Buy sends (Standard/Fast/Armored/Swarm) |
+| 1/2/3/4 | Buy tier 2 sends (Healer/Shielded/Flying/Regen — unlock mid-game) |
 | SPACE / Start Wave btn | Start next wave / Vote ready (versus) |
 | TAB / Speed btn | Cycle game speed (0x/0.5x/1x/1.5x/2x/3x) |
 | P | Pause menu |
@@ -85,7 +86,7 @@ Standard, Fast, Armored, Swarm, Healer, Boss, Group, Splitter, Shielded, Evasive
 
 ### Economy Triangle
 - **Towers** — Direct defence
-- **Sends** — Spend gold to add creeps to your wave for permanent income bonus (in versus: sends go to opponent)
+- **Sends** — Spend gold to add creeps to your wave for permanent income bonus (in versus: sends go to opponent). Tier 1 always available (Z/X/C/V), tier 2 unlocks at waves 10/15/20 (1/2/3/4). Costs scale with wave progression.
 - **Frontier** — Invest in passive income buildings with faction-flavored mechanics
 
 ### Difficulty System

--- a/src/data/SendCreepTypes.ts
+++ b/src/data/SendCreepTypes.ts
@@ -6,8 +6,24 @@ export interface SendCreepOption {
   cost: number;
   incomeReward: number; // permanent income bonus per wave
   description: string;
+  tier: number; // 1 = basic, 2 = unlocks later
+  unlockWave: number; // available from this wave onward (0 = always)
 }
 
+/** Get scaled cost for a send based on current wave */
+export function getSendCost(base: number, wave: number): number {
+  // +10% per 5 waves, rounded to nearest 5
+  const scale = 1 + Math.floor(wave / 5) * 0.1;
+  return Math.round((base * scale) / 5) * 5;
+}
+
+/** Get scaled income reward for a send based on current wave */
+export function getSendIncome(base: number, wave: number): number {
+  // +0.5 per 10 waves (late sends are more rewarding to compensate for cost)
+  return +(base + Math.floor(wave / 10) * 0.5).toFixed(1);
+}
+
+// === Tier 1 — always available ===
 export const SEND_OPTIONS: SendCreepOption[] = [
   {
     id: 'send_standard',
@@ -16,7 +32,9 @@ export const SEND_OPTIONS: SendCreepOption[] = [
     count: 4,
     cost: 20,
     incomeReward: 2,
-    description: '+4 standard creeps, +2 income/wave',
+    description: '+4 standard creeps',
+    tier: 1,
+    unlockWave: 0,
   },
   {
     id: 'send_fast',
@@ -25,7 +43,9 @@ export const SEND_OPTIONS: SendCreepOption[] = [
     count: 3,
     cost: 30,
     incomeReward: 3,
-    description: '+3 fast creeps, +3 income/wave',
+    description: '+3 fast creeps',
+    tier: 1,
+    unlockWave: 0,
   },
   {
     id: 'send_armored',
@@ -34,7 +54,9 @@ export const SEND_OPTIONS: SendCreepOption[] = [
     count: 2,
     cost: 50,
     incomeReward: 5,
-    description: '+2 armored creeps, +5 income/wave',
+    description: '+2 armored creeps',
+    tier: 1,
+    unlockWave: 0,
   },
   {
     id: 'send_swarm',
@@ -43,6 +65,54 @@ export const SEND_OPTIONS: SendCreepOption[] = [
     count: 5,
     cost: 15,
     incomeReward: 1,
-    description: '+15 tiny creeps, +1 income/wave',
+    description: '+15 tiny creeps',
+    tier: 1,
+    unlockWave: 0,
+  },
+
+  // === Tier 2 — unlock at wave 10+ ===
+  {
+    id: 'send_healer',
+    name: 'Healer Pack',
+    creepType: 'healer',
+    count: 2,
+    cost: 70,
+    incomeReward: 6,
+    description: '+2 healers (heal nearby)',
+    tier: 2,
+    unlockWave: 10,
+  },
+  {
+    id: 'send_shielded',
+    name: 'Shielded Pack',
+    creepType: 'shielded',
+    count: 2,
+    cost: 80,
+    incomeReward: 7,
+    description: '+2 shielded (1 dmg/hit cap)',
+    tier: 2,
+    unlockWave: 10,
+  },
+  {
+    id: 'send_flying',
+    name: 'Flying Squad',
+    creepType: 'flying',
+    count: 3,
+    cost: 90,
+    incomeReward: 8,
+    description: '+3 flying (bypass maze)',
+    tier: 2,
+    unlockWave: 15,
+  },
+  {
+    id: 'send_regen',
+    name: 'Regen Pack',
+    creepType: 'regenerator',
+    count: 2,
+    cost: 100,
+    incomeReward: 9,
+    description: '+2 regenerators (2%hp/s)',
+    tier: 2,
+    unlockWave: 20,
   },
 ];

--- a/src/scenes/ChangelogScene.ts
+++ b/src/scenes/ChangelogScene.ts
@@ -5,8 +5,11 @@ import { TowerSelectBar } from '../ui/TowerSelectBar';
 // In-app changelog — recent changes shown to the player
 const CHANGELOG_ENTRIES = [
   {
-    version: 'v19 — Difficulty Scaling & Bug Fixes',
+    version: 'v19 — Difficulty Scaling, Send Tiers & Bug Fixes',
     changes: [
+      'Send cost scaling: costs rise +10% per 5 waves, income rewards scale slightly to compensate',
+      'Tier 2 sends: Healer (w10+), Shielded (w10+), Flying (w15+), Regen (w20+) — hotkeys 1/2/3/4',
+      'Send panel updates each wave with current costs and unlock status',
       'Fixed DoT/beam rounding bug: Virus, burn, and Firewall beam were dealing 0 damage at 60fps',
       'Quadratic HP scaling: late-wave creeps are much tougher (wave 20: 340 HP, wave 30: 620 HP)',
       'Themed late-wave compositions: healer+tank packs, speed rushes, regen DPS checks, flying bypasses',

--- a/src/systems/modes/BattleMode.ts
+++ b/src/systems/modes/BattleMode.ts
@@ -68,7 +68,7 @@ export class BattleMode implements GameMode {
       this.ctx.sendMgr.queueSend({
         id: send.id, name: send.name, creepType: send.creepType,
         count: send.count, cost: 0, incomeReward: send.incomeReward,
-        description: send.description,
+        description: send.description, tier: 1, unlockWave: 0,
       });
       this.ctx.eventLog.gameMessage(`Incoming send: ${send.name}!`);
       return true;
@@ -105,7 +105,7 @@ export class BattleMode implements GameMode {
       this.ctx.sendMgr.queueSend({
         id: send.id, name: send.name, creepType: send.creepType,
         count: send.count, cost: 0, incomeReward: send.incomeReward,
-        description: send.description,
+        description: send.description, tier: 1, unlockWave: 0,
       });
     }
 

--- a/src/systems/modes/StandardMode.ts
+++ b/src/systems/modes/StandardMode.ts
@@ -18,6 +18,7 @@ export class StandardMode implements GameMode {
   readonly id: MatchMode;
   private ctx!: GameModeContext;
   private sendPanel!: SendPanel;
+  private currentWave: number = 0;
   frontierMgr!: FrontierManager;
   frontierPanel!: FrontierPanel;
 
@@ -29,9 +30,10 @@ export class StandardMode implements GameMode {
     this.ctx = ctx;
 
     // Send panel
-    this.sendPanel = new SendPanel(ctx.scene, (opt: SendCreepOption) => {
+    this.sendPanel = new SendPanel(ctx.scene, (opt: SendCreepOption, scaledCost: number, scaledIncome: number) => {
       if (!this.canStartWave()) return; // only between waves
-      if (!ctx.economy.spend(opt.cost)) return;
+      if (this.currentWave < opt.unlockWave) return; // not unlocked yet
+      if (!ctx.economy.spend(scaledCost)) return;
 
       if (ctx.versus && ctx.versus.isConnected()) {
         ctx.versus.send({ type: 'send_purchased', sendOptionId: opt.id });
@@ -40,12 +42,18 @@ export class StandardMode implements GameMode {
       } else {
         ctx.sendMgr.queueSend(opt);
       }
-      ctx.incomeMgr.addSendBonus(opt.incomeReward);
-      ctx.eventLog.sendQueued(opt.name, opt.cost);
-      ctx.statsTracker.recordSendSpent(opt.cost);
-      ctx.statsTracker.recordSendIncome(opt.incomeReward);
-      ctx.statsTracker.recordGoldSpent(opt.cost);
+      ctx.incomeMgr.addSendBonus(scaledIncome);
+      ctx.eventLog.sendQueued(opt.name, scaledCost);
+      ctx.statsTracker.recordSendSpent(scaledCost);
+      ctx.statsTracker.recordSendIncome(scaledIncome);
+      ctx.statsTracker.recordGoldSpent(scaledCost);
     }, ctx.sidebarTopY);
+
+    // Track wave for send scaling/unlocks
+    ctx.eventBus.on('waveStarted', (waveNum: number) => {
+      this.currentWave = waveNum;
+      this.sendPanel.setWave(waveNum);
+    });
 
     // Frontier
     this.frontierMgr = new FrontierManager(ctx.eventBus, ctx.incomeMgr, ctx.faction);

--- a/src/ui/SendPanel.ts
+++ b/src/ui/SendPanel.ts
@@ -1,22 +1,36 @@
 import { SIDEBAR_WIDTH } from '../config';
-import { SEND_OPTIONS, SendCreepOption } from '../data/SendCreepTypes';
+import { SEND_OPTIONS, SendCreepOption, getSendCost, getSendIncome } from '../data/SendCreepTypes';
 
-const SEND_HOTKEYS = ['Z', 'X', 'C', 'V'];
+const SEND_HOTKEYS = ['Z', 'X', 'C', 'V', '1', '2', '3', '4'];
 
 export class SendPanel {
   private scene: Phaser.Scene;
   private container: Phaser.GameObjects.Container;
-  private onSend: (option: SendCreepOption) => void;
+  private onSend: (option: SendCreepOption, scaledCost: number, scaledIncome: number) => void;
+  private currentWave: number = 0;
+  private labels: { text: Phaser.GameObjects.Text; opt: SendCreepOption; hotkey: string }[] = [];
+  private hotkeyListeners: (() => void)[] = [];
 
   static readonly HEIGHT = 100;
 
-  constructor(scene: Phaser.Scene, onSend: (option: SendCreepOption) => void, yOffset: number = 0) {
+  constructor(
+    scene: Phaser.Scene,
+    onSend: (option: SendCreepOption, scaledCost: number, scaledIncome: number) => void,
+    yOffset: number = 0,
+  ) {
     this.scene = scene;
     this.onSend = onSend;
     this.container = scene.add.container(0, yOffset).setDepth(28);
 
     this.buildPanel();
     this.registerHotkeys();
+  }
+
+  /** Call when wave changes to update send availability and costs */
+  setWave(wave: number): void {
+    if (wave === this.currentWave) return;
+    this.currentWave = wave;
+    this.updateLabels();
   }
 
   private buildPanel(): void {
@@ -40,37 +54,121 @@ export class SendPanel {
     });
     this.container.add(subtitle);
 
+    this.labels = [];
     for (let i = 0; i < SEND_OPTIONS.length; i++) {
       const opt = SEND_OPTIONS[i];
       const hotkey = SEND_HOTKEYS[i] || '';
       const y = 24 + i * 17;
 
-      const label = hotkey
-        ? `[${hotkey}] ${opt.name} (${opt.cost}g) +${opt.incomeReward}/w`
-        : `${opt.name} (${opt.cost}g) +${opt.incomeReward}/w`;
-
-      const text = this.scene.add.text(8, y, label, {
-        fontSize: '12px', color: '#cccccc', fontFamily: 'monospace',
+      // Scrollable area check — if more than 4 sends, we need tighter spacing
+      const text = this.scene.add.text(8, y, '', {
+        fontSize: '10px', color: '#cccccc', fontFamily: 'monospace',
       });
 
       this.container.add(text);
       text.setInteractive({ useHandCursor: true });
-      text.on('pointerdown', () => this.onSend(opt));
-      text.on('pointerover', () => text.setColor('#ffffff'));
-      text.on('pointerout', () => text.setColor('#cccccc'));
+      text.on('pointerdown', () => {
+        const cost = getSendCost(opt.cost, this.currentWave);
+        const income = getSendIncome(opt.incomeReward, this.currentWave);
+        this.onSend(opt, cost, income);
+      });
+      text.on('pointerover', () => {
+        if (this.currentWave >= opt.unlockWave) text.setColor('#ffffff');
+      });
+      text.on('pointerout', () => {
+        this.updateLabelColor(text, opt);
+      });
+
+      this.labels.push({ text, opt, hotkey });
+    }
+
+    this.updateLabels();
+  }
+
+  private updateLabels(): void {
+    // Partition into unlocked and locked
+    const unlocked = this.labels.filter(l => this.currentWave >= l.opt.unlockWave);
+    const locked = this.labels.filter(l => this.currentWave < l.opt.unlockWave);
+
+    // Position unlocked sends first
+    let idx = 0;
+    for (const l of unlocked) {
+      const y = 24 + idx * 14;
+      const cost = getSendCost(l.opt.cost, this.currentWave);
+      const income = getSendIncome(l.opt.incomeReward, this.currentWave);
+      const tierTag = l.opt.tier >= 2 ? ' T2' : '';
+      const label = l.hotkey
+        ? `[${l.hotkey}] ${l.opt.name} (${cost}g) +${income}/w${tierTag}`
+        : `${l.opt.name} (${cost}g) +${income}/w${tierTag}`;
+      l.text.setText(label);
+      l.text.setY(y);
+      l.text.setVisible(true);
+      this.updateLabelColor(l.text, l.opt);
+      idx++;
+    }
+
+    // Show next unlock hint if any locked sends exist
+    for (const l of locked) {
+      const y = 24 + idx * 14;
+      l.text.setText(`  ${l.opt.name} — unlocks wave ${l.opt.unlockWave}`);
+      l.text.setY(y);
+      l.text.setVisible(true);
+      l.text.setColor('#444444');
+      idx++;
+    }
+
+    // Resize panel height dynamically
+    const neededH = Math.max(SendPanel.HEIGHT, 28 + idx * 14);
+    if (neededH !== this._currentH) {
+      this._currentH = neededH;
+      // Redraw background
+      const bg = this.container.getAt(0) as Phaser.GameObjects.Graphics;
+      bg.clear();
+      bg.fillStyle(0x151515, 1);
+      bg.fillRect(0, 0, SIDEBAR_WIDTH, neededH);
+      bg.lineStyle(1, 0x333333, 1);
+      bg.strokeRect(0, 0, SIDEBAR_WIDTH, neededH);
+    }
+  }
+
+  private _currentH = SendPanel.HEIGHT;
+
+  private updateLabelColor(text: Phaser.GameObjects.Text, opt: SendCreepOption): void {
+    if (this.currentWave < opt.unlockWave) {
+      text.setColor('#444444');
+    } else if (opt.tier >= 2) {
+      text.setColor('#88aaff');
+    } else {
+      text.setColor('#cccccc');
     }
   }
 
   private registerHotkeys(): void {
+    // Clean up old listeners
+    for (const cleanup of this.hotkeyListeners) cleanup();
+    this.hotkeyListeners = [];
+
     for (let i = 0; i < SEND_OPTIONS.length && i < SEND_HOTKEYS.length; i++) {
       const opt = SEND_OPTIONS[i];
-      this.scene.input.keyboard!.on(`keydown-${SEND_HOTKEYS[i]}`, () => {
-        this.onSend(opt);
+      const key = SEND_HOTKEYS[i];
+      const handler = () => {
+        if (this.currentWave < opt.unlockWave) return;
+        const cost = getSendCost(opt.cost, this.currentWave);
+        const income = getSendIncome(opt.incomeReward, this.currentWave);
+        this.onSend(opt, cost, income);
+      };
+      this.scene.input.keyboard!.on(`keydown-${key}`, handler);
+      this.hotkeyListeners.push(() => {
+        this.scene.input.keyboard!.off(`keydown-${key}`, handler);
       });
     }
   }
 
   getContainer(): Phaser.GameObjects.Container {
     return this.container;
+  }
+
+  getHeight(): number {
+    return this._currentH;
   }
 }


### PR DESCRIPTION
Send costs now scale +10% per 5 waves to prevent early-game send spam from being dominant. Income rewards also scale +0.5 per 10 waves so late sends remain worthwhile despite higher cost.

Add 4 tier 2 send types that unlock progressively:
- Healer Pack (70g, wave 10+): 2 healers that sustain nearby creeps
- Shielded Pack (80g, wave 10+): 2 shielded with 1-damage-per-hit cap
- Flying Squad (90g, wave 15+): 3 flyers that bypass the maze
- Regen Pack (100g, wave 20+): 2 regenerators with 2% HP/s

Send panel is now wave-aware — shows scaled costs, tier tags, unlock status for locked sends, and hotkeys 1/2/3/4 for tier 2. StandardMode tracks wave via EventBus and passes it to the panel each wave.