### PR TITLE
Add procedural random map generator with daily seed support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 2026-03-20
+
+### Procedural Random Map Generator
+- **New "Random" map option** in the map picker (menu, lobby, versus). Generates a unique map from a seed using chunk-based terrain features.
+- **6 layout templates** (classic, dual_entry, siege, gauntlet, diagonal, corridor) define entry/exit positions. The generator picks one randomly and fills terrain procedurally.
+- **Terrain feature library**: Lakes (circles), ridges (vertical walls with gaps), pillars (clusters), walls (horizontal with gaps), islands (blocked core + NoBuild ring), and boulder clusters. Features are randomly placed and validated via A* to guarantee all paths remain passable.
+- **Difficulty-linked terrain**: Easy maps are open (8-10% blocked), Insane maps are cramped (18-22% blocked) with more NoBuild zones and longer minimum paths. Each difficulty level feels structurally different.
+- **Daily seed toggle**: When Random is selected, a "Daily" toggle appears. ON = everyone gets the same map that day (seed = YYYYMMDD). OFF = fresh random seed each game.
+- **Versus integration**: Random maps in 1v1 use the existing shared seed mechanism — both players generate identical maps from the same seed.
+- **Seed display**: The active seed is shown in the top-right corner during gameplay so players can share/compare maps.
+- **Seeded PRNG**: Uses mulberry32 for fast, deterministic generation. Same seed + same difficulty = identical map every time.
+
 ## 2026-03-18
 
 ### Send Scaling & Tier 2 Sends

--- a/GAMEMODES.md
+++ b/GAMEMODES.md
@@ -133,7 +133,8 @@ Buy items in the left sidebar. Each slot has 3 upgrade tiers.
 Peer-to-peer competitive mode. No server required — uses WebRTC with manual SDP exchange.
 
 - **Connection**: Host creates offer code (clipboard) → send to opponent → opponent pastes, gets answer code → host pastes answer → connected.
-- **Setup**: Host picks map + difficulty. Both pick factions. Then draft modifiers.
+- **Setup**: Host picks map + difficulty (including Random). Both pick factions. Then draft modifiers.
+- **Random maps in versus**: When host selects Random, both players generate the identical map from the shared seed.
 - **Waves**: 30. Mirrored via shared seed — both players face identical spawn patterns.
 - **Sends go to opponent**: Your send purchases (Z/X/C/V) spawn extra creeps in the opponent's game. Their sends come to you.
 - **Wave timer**: 60s for first wave, 30s between subsequent waves. Press SPACE to vote ready — wave starts when both ready OR timer expires.

--- a/README.md
+++ b/README.md
@@ -108,8 +108,9 @@ Easy/Normal/Hard/Insane. Each creep type interprets difficulty individually — 
 - Star topology: host relays tower ops to all players
 - 3 dedicated circle maps (2P, 3P, 4P)
 
-### Maps (8 + 3 circle)
+### Maps (8 + Random + 3 circle)
 **Standard:** Plains, Crossroads, Fortress, Serpentine, Islands, Gauntlet, Spiral, Siege.
+**Random:** Procedurally generated map from a seed. 6 layout templates × terrain features scaled by difficulty. Daily seed toggle locks the same map for all players that day. Versus uses shared seed for identical maps.
 **Circle Co-op:** Circle 2P, Circle 3P, Circle 4P.
 
 ## Tech Stack

--- a/src/data/MapGenerator.ts
+++ b/src/data/MapGenerator.ts
@@ -1,0 +1,411 @@
+import { GRID_COLS, GRID_ROWS } from '../config';
+import { MapDefinition } from './Maps';
+import { DifficultyLevel } from './Difficulty';
+import { findPath } from '../systems/Pathfinding';
+import { Grid } from '../systems/Grid';
+
+// ── Seeded PRNG (mulberry32) ──────────────────────────────────
+function mulberry32(seed: number): () => number {
+  return () => {
+    seed |= 0;
+    seed = (seed + 0x6D2B79F5) | 0;
+    let t = Math.imul(seed ^ (seed >>> 15), 1 | seed);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+// ── Layout Templates ──────────────────────────────────────────
+interface LayoutTemplate {
+  name: string;
+  entries: { col: number; row: number }[];
+  exits: { col: number; row: number }[];
+}
+
+const MID_COL = Math.floor(GRID_COLS / 2);
+const MID_ROW = Math.floor(GRID_ROWS / 2);
+
+const LAYOUT_TEMPLATES: LayoutTemplate[] = [
+  {
+    name: 'classic',
+    entries: [{ col: 0, row: MID_ROW }],
+    exits: [{ col: GRID_COLS - 1, row: MID_ROW }],
+  },
+  {
+    name: 'dual_entry',
+    entries: [{ col: 0, row: 4 }, { col: 0, row: GRID_ROWS - 5 }],
+    exits: [{ col: GRID_COLS - 1, row: MID_ROW }],
+  },
+  {
+    name: 'siege',
+    entries: [
+      { col: 0, row: Math.floor(GRID_ROWS / 4) },
+      { col: 0, row: Math.floor(GRID_ROWS * 3 / 4) },
+    ],
+    exits: [
+      { col: GRID_COLS - 1, row: Math.floor(GRID_ROWS / 4) },
+      { col: GRID_COLS - 1, row: Math.floor(GRID_ROWS * 3 / 4) },
+    ],
+  },
+  {
+    name: 'gauntlet',
+    entries: [
+      { col: 0, row: MID_ROW },
+      { col: GRID_COLS - 1, row: MID_ROW },
+      { col: MID_COL, row: 0 },
+      { col: MID_COL, row: GRID_ROWS - 1 },
+    ],
+    exits: [{ col: MID_COL, row: MID_ROW }],
+  },
+  {
+    name: 'diagonal',
+    entries: [{ col: 0, row: 1 }],
+    exits: [{ col: GRID_COLS - 1, row: GRID_ROWS - 2 }],
+  },
+  {
+    name: 'corridor',
+    entries: [{ col: 0, row: 2 }],
+    exits: [{ col: GRID_COLS - 1, row: GRID_ROWS - 3 }],
+  },
+];
+
+// ── Terrain Feature Library ───────────────────────────────────
+type Pos = { col: number; row: number };
+
+interface TerrainFeature {
+  cells: Pos[];
+}
+
+function inBounds(c: number, r: number): boolean {
+  return c >= 0 && c < GRID_COLS && r >= 0 && r < GRID_ROWS;
+}
+
+function makeCircle(cx: number, cy: number, radius: number): Pos[] {
+  const ps: Pos[] = [];
+  for (let c = cx - radius; c <= cx + radius; c++) {
+    for (let r = cy - radius; r <= cy + radius; r++) {
+      const dx = c - cx, dy = r - cy;
+      if (dx * dx + dy * dy <= radius * radius && inBounds(c, r)) {
+        ps.push({ col: c, row: r });
+      }
+    }
+  }
+  return ps;
+}
+
+function makeRect(c1: number, r1: number, c2: number, r2: number): Pos[] {
+  const ps: Pos[] = [];
+  for (let c = c1; c <= c2; c++) {
+    for (let r = r1; r <= r2; r++) {
+      if (inBounds(c, r)) ps.push({ col: c, row: r });
+    }
+  }
+  return ps;
+}
+
+type FeatureGenerator = (rng: () => number) => TerrainFeature;
+
+/** Lake: circular blocked area */
+function genLake(rng: () => number): TerrainFeature {
+  const radius = 2 + Math.floor(rng() * 3); // 2-4
+  const cx = 3 + Math.floor(rng() * (GRID_COLS - 6));
+  const cy = 3 + Math.floor(rng() * (GRID_ROWS - 6));
+  return { cells: makeCircle(cx, cy, radius) };
+}
+
+/** Ridge: vertical wall with gaps */
+function genRidge(rng: () => number): TerrainFeature {
+  const width = 1 + Math.floor(rng() * 2); // 1-2
+  const height = 6 + Math.floor(rng() * 7); // 6-12
+  const c = 4 + Math.floor(rng() * (GRID_COLS - 8));
+  const r = 2 + Math.floor(rng() * (GRID_ROWS - height - 4));
+  const cells: Pos[] = [];
+  // Place wall with 2-3 gaps
+  const gapCount = 2 + Math.floor(rng() * 2);
+  const gapPositions = new Set<number>();
+  for (let g = 0; g < gapCount; g++) {
+    gapPositions.add(r + 1 + Math.floor(rng() * (height - 2)));
+  }
+  for (let row = r; row < r + height; row++) {
+    if (gapPositions.has(row)) continue;
+    for (let w = 0; w < width; w++) {
+      if (inBounds(c + w, row)) cells.push({ col: c + w, row });
+    }
+  }
+  return { cells };
+}
+
+/** Pillars: 3-5 small circles in a cluster */
+function genPillars(rng: () => number): TerrainFeature {
+  const count = 3 + Math.floor(rng() * 3); // 3-5
+  const cx = 5 + Math.floor(rng() * (GRID_COLS - 10));
+  const cy = 5 + Math.floor(rng() * (GRID_ROWS - 10));
+  const cells: Pos[] = [];
+  for (let i = 0; i < count; i++) {
+    const ox = Math.floor(rng() * 8) - 4;
+    const oy = Math.floor(rng() * 8) - 4;
+    cells.push(...makeCircle(cx + ox, cy + oy, 1));
+  }
+  return { cells };
+}
+
+/** Wall: horizontal rect with gaps */
+function genWall(rng: () => number): TerrainFeature {
+  const width = 8 + Math.floor(rng() * 9); // 8-16
+  const height = 1 + Math.floor(rng() * 2); // 1-2
+  const c = 2 + Math.floor(rng() * (GRID_COLS - width - 4));
+  const r = 3 + Math.floor(rng() * (GRID_ROWS - 6));
+  const cells: Pos[] = [];
+  const gapCount = 2 + Math.floor(rng() * 2);
+  const gapCols = new Set<number>();
+  for (let g = 0; g < gapCount; g++) {
+    gapCols.add(c + 1 + Math.floor(rng() * (width - 2)));
+  }
+  for (let col = c; col < c + width; col++) {
+    if (gapCols.has(col)) continue;
+    for (let h = 0; h < height; h++) {
+      if (inBounds(col, r + h)) cells.push({ col, row: r + h });
+    }
+  }
+  return { cells };
+}
+
+/** Island: large circle with NoBuild ring */
+function genIsland(rng: () => number): { blocked: Pos[]; noBuild: Pos[] } {
+  const radius = 3 + Math.floor(rng() * 3); // 3-5
+  const cx = radius + 2 + Math.floor(rng() * (GRID_COLS - 2 * radius - 4));
+  const cy = radius + 2 + Math.floor(rng() * (GRID_ROWS - 2 * radius - 4));
+  const blocked = makeCircle(cx, cy, radius);
+  const blockedSet = new Set(blocked.map(p => `${p.col},${p.row}`));
+  const ring = makeCircle(cx, cy, radius + 1).filter(
+    p => !blockedSet.has(`${p.col},${p.row}`)
+  );
+  return { blocked, noBuild: ring };
+}
+
+/** Boulder cluster: 3-6 random adjacent blocked cells */
+function genBoulders(rng: () => number): TerrainFeature {
+  const count = 3 + Math.floor(rng() * 4); // 3-6
+  const cx = 3 + Math.floor(rng() * (GRID_COLS - 6));
+  const cy = 3 + Math.floor(rng() * (GRID_ROWS - 6));
+  const cells: Pos[] = [];
+  const placed = new Set<string>();
+  let c = cx, r = cy;
+  for (let i = 0; i < count; i++) {
+    if (inBounds(c, r) && !placed.has(`${c},${r}`)) {
+      cells.push({ col: c, row: r });
+      placed.add(`${c},${r}`);
+    }
+    // Random walk
+    const dir = Math.floor(rng() * 4);
+    if (dir === 0) c++;
+    else if (dir === 1) c--;
+    else if (dir === 2) r++;
+    else r--;
+  }
+  return { cells };
+}
+
+const FEATURE_GENERATORS: FeatureGenerator[] = [
+  genLake, genRidge, genPillars, genWall, genBoulders,
+];
+
+// ── Difficulty-Linked Parameters ──────────────────────────────
+interface TerrainParams {
+  densityMin: number;
+  densityMax: number;
+  features: [number, number]; // [min, max] feature count
+  noBuildPct: number;
+  minPath: number;
+}
+
+const DIFFICULTY_TERRAIN: Record<DifficultyLevel, TerrainParams> = {
+  easy:   { densityMin: 0.08, densityMax: 0.10, features: [2, 3], noBuildPct: 0,    minPath: 20 },
+  normal: { densityMin: 0.12, densityMax: 0.15, features: [3, 5], noBuildPct: 0.02, minPath: 25 },
+  hard:   { densityMin: 0.15, densityMax: 0.18, features: [4, 6], noBuildPct: 0.04, minPath: 30 },
+  insane: { densityMin: 0.18, densityMax: 0.22, features: [5, 7], noBuildPct: 0.07, minPath: 35 },
+};
+
+// ── Main Generator ────────────────────────────────────────────
+
+function posKey(p: Pos): string { return `${p.col},${p.row}`; }
+
+/** Check that every entry can reach every exit using A* */
+function validatePaths(entries: Pos[], exits: Pos[], blocked: Set<string>): boolean {
+  // Build a temporary grid to check pathability
+  const tempMap: MapDefinition = {
+    id: 'random' as any,
+    name: '', description: '',
+    entries, exits,
+    blocked: Array.from(blocked).map(k => {
+      const [c, r] = k.split(',').map(Number);
+      return { col: c, row: r };
+    }),
+    noBuild: [],
+  };
+  const grid = new Grid(tempMap);
+  for (const entry of entries) {
+    for (const exit of exits) {
+      const path = findPath(grid, entry, exit);
+      if (!path) return false;
+    }
+  }
+  return true;
+}
+
+/** Get shortest path length across all entry→exit pairs */
+function getShortestPathLength(entries: Pos[], exits: Pos[], blocked: Set<string>): number {
+  const tempMap: MapDefinition = {
+    id: 'random' as any,
+    name: '', description: '',
+    entries, exits,
+    blocked: Array.from(blocked).map(k => {
+      const [c, r] = k.split(',').map(Number);
+      return { col: c, row: r };
+    }),
+    noBuild: [],
+  };
+  const grid = new Grid(tempMap);
+  let shortest = Infinity;
+  for (const entry of entries) {
+    for (const exit of exits) {
+      const path = findPath(grid, entry, exit);
+      if (path) shortest = Math.min(shortest, path.length);
+    }
+  }
+  return shortest;
+}
+
+export function generateRandomMap(seed: number, difficulty: DifficultyLevel): MapDefinition {
+  const rng = mulberry32(seed);
+  const params = DIFFICULTY_TERRAIN[difficulty];
+
+  // 1. Pick a random layout template
+  const templateIdx = Math.floor(rng() * LAYOUT_TEMPLATES.length);
+  const template = LAYOUT_TEMPLATES[templateIdx];
+  const entries = template.entries;
+  const exits = template.exits;
+
+  // Reserve cells around entries/exits (2-cell radius)
+  const reserved = new Set<string>();
+  for (const p of [...entries, ...exits]) {
+    for (let dc = -2; dc <= 2; dc++) {
+      for (let dr = -2; dr <= 2; dr++) {
+        const c = p.col + dc, r = p.row + dr;
+        if (inBounds(c, r)) reserved.add(posKey({ col: c, row: r }));
+      }
+    }
+  }
+
+  // 2. Place terrain features
+  const blocked = new Set<string>();
+  const noBuildCells: Pos[] = [];
+  const totalCells = GRID_COLS * GRID_ROWS;
+  const targetDensity = params.densityMin + rng() * (params.densityMax - params.densityMin);
+  const maxBlocked = Math.floor(totalCells * targetDensity);
+  const featureCount = params.features[0] + Math.floor(rng() * (params.features[1] - params.features[0] + 1));
+
+  for (let f = 0; f < featureCount && blocked.size < maxBlocked; f++) {
+    const genIdx = Math.floor(rng() * (FEATURE_GENERATORS.length + 1)); // +1 for island
+    let newBlocked: Pos[];
+    let newNoBuild: Pos[] = [];
+
+    if (genIdx >= FEATURE_GENERATORS.length) {
+      // Island feature (has NoBuild ring)
+      const island = genIsland(rng);
+      newBlocked = island.blocked;
+      newNoBuild = island.noBuild;
+    } else {
+      const feature = FEATURE_GENERATORS[genIdx](rng);
+      newBlocked = feature.cells;
+    }
+
+    // Filter out reserved cells and entry/exit cells
+    const entryExitKeys = new Set([...entries, ...exits].map(posKey));
+    newBlocked = newBlocked.filter(p => !reserved.has(posKey(p)) && !entryExitKeys.has(posKey(p)));
+    newNoBuild = newNoBuild.filter(p => !reserved.has(posKey(p)) && !entryExitKeys.has(posKey(p)));
+
+    // Would we exceed density?
+    if (blocked.size + newBlocked.length > maxBlocked * 1.2) continue;
+
+    // Tentatively add
+    const snapshot = new Set(blocked);
+    for (const p of newBlocked) blocked.add(posKey(p));
+
+    // Validate paths
+    if (!validatePaths(entries, exits, blocked)) {
+      // Revert
+      for (const key of blocked) {
+        if (!snapshot.has(key)) blocked.delete(key);
+      }
+    } else {
+      // Keep it
+      for (const p of newNoBuild) {
+        if (!blocked.has(posKey(p))) noBuildCells.push(p);
+      }
+    }
+  }
+
+  // 3. If path too short, add wall features to lengthen it
+  let retries = 0;
+  while (retries < 5) {
+    const pathLen = getShortestPathLength(entries, exits, blocked);
+    if (pathLen >= params.minPath || pathLen === Infinity) break;
+
+    const wall = genWall(rng);
+    const entryExitKeys = new Set([...entries, ...exits].map(posKey));
+    const validCells = wall.cells.filter(p => !reserved.has(posKey(p)) && !entryExitKeys.has(posKey(p)));
+
+    const snapshot = new Set(blocked);
+    for (const p of validCells) blocked.add(posKey(p));
+
+    if (!validatePaths(entries, exits, blocked)) {
+      for (const key of blocked) {
+        if (!snapshot.has(key)) blocked.delete(key);
+      }
+    }
+    retries++;
+  }
+
+  // 4. Add NoBuild zones based on difficulty
+  if (params.noBuildPct > 0) {
+    const noBuildTarget = Math.floor(totalCells * params.noBuildPct);
+    let placed = noBuildCells.length;
+    let attempts = 0;
+    while (placed < noBuildTarget && attempts < noBuildTarget * 3) {
+      const c = Math.floor(rng() * GRID_COLS);
+      const r = Math.floor(rng() * GRID_ROWS);
+      const key = posKey({ col: c, row: r });
+      if (!blocked.has(key) && !reserved.has(key)) {
+        noBuildCells.push({ col: c, row: r });
+        placed++;
+      }
+      attempts++;
+    }
+  }
+
+  // 5. Convert to MapDefinition
+  const blockedArr: Pos[] = Array.from(blocked).map(k => {
+    const [c, r] = k.split(',').map(Number);
+    return { col: c, row: r };
+  });
+
+  // Deduplicate noBuild cells that overlap blocked
+  const noBuildFiltered = noBuildCells.filter(p => !blocked.has(posKey(p)));
+
+  return {
+    id: 'random' as any,
+    name: `Random #${seed}`,
+    description: `Seed: ${seed} — ${template.name} layout`,
+    entries,
+    exits,
+    blocked: blockedArr,
+    noBuild: noBuildFiltered,
+  };
+}
+
+// ── Daily Seed ────────────────────────────────────────────────
+export function getDailySeed(): number {
+  const d = new Date();
+  return d.getFullYear() * 10000 + (d.getMonth() + 1) * 100 + d.getDate();
+}

--- a/src/data/Maps.ts
+++ b/src/data/Maps.ts
@@ -1,6 +1,6 @@
 import { GRID_COLS, GRID_ROWS } from '../config';
 
-export type MapId = 'plains' | 'crossroads' | 'fortress' | 'serpentine' | 'islands' | 'gauntlet' | 'spiral' | 'siege' | 'hero_plains' | 'circle_2p' | 'circle_3p' | 'circle_4p';
+export type MapId = 'plains' | 'crossroads' | 'fortress' | 'serpentine' | 'islands' | 'gauntlet' | 'spiral' | 'siege' | 'random' | 'hero_plains' | 'circle_2p' | 'circle_3p' | 'circle_4p';
 
 export interface MapDefinition {
   id: MapId;
@@ -291,6 +291,15 @@ export const MAPS: Record<MapId, MapDefinition> = {
     })(),
     noBuild: [],
   },
+  random: {
+    id: 'random',
+    name: 'Random',
+    description: 'Procedurally generated — unique every time.',
+    entries: [{ col: 0, row: MID_ROW }],
+    exits: [{ col: GRID_COLS - 1, row: MID_ROW }],
+    blocked: [],
+    noBuild: [],
+  },
   hero_plains: {
     id: 'hero_plains',
     name: 'Hero Plains',
@@ -507,5 +516,5 @@ export const MAPS: Record<MapId, MapDefinition> = {
   })(),
 };
 
-export const MAP_ORDER: MapId[] = ['plains', 'crossroads', 'fortress', 'serpentine', 'islands', 'gauntlet', 'spiral', 'siege'];
+export const MAP_ORDER: MapId[] = ['plains', 'crossroads', 'fortress', 'serpentine', 'islands', 'gauntlet', 'spiral', 'siege', 'random'];
 export const CIRCLE_MAP_ORDER: MapId[] = ['circle_2p', 'circle_3p', 'circle_4p'];

--- a/src/scenes/ChangelogScene.ts
+++ b/src/scenes/ChangelogScene.ts
@@ -5,6 +5,18 @@ import { TowerSelectBar } from '../ui/TowerSelectBar';
 // In-app changelog — recent changes shown to the player
 const CHANGELOG_ENTRIES = [
   {
+    version: 'v20 — Procedural Random Maps',
+    changes: [
+      'New "Random" map in the map picker — procedurally generated from a seed',
+      '6 layout templates (classic, dual entry, siege, gauntlet, diagonal, corridor)',
+      'Terrain features: lakes, ridges, pillars, walls, islands, boulder clusters',
+      'Difficulty-linked density: Easy = open, Insane = cramped with NoBuild zones',
+      'Daily seed toggle: same map for everyone that day (seed = YYYYMMDD)',
+      'Versus uses shared seed — both players get identical random maps',
+      'Seed displayed in top-right corner during gameplay',
+    ],
+  },
+  {
     version: 'v19 — Difficulty Scaling, Send Tiers & Bug Fixes',
     changes: [
       'Send cost scaling: costs rise +10% per 5 waves, income rewards scale slightly to compensate',

--- a/src/scenes/DraftScene.ts
+++ b/src/scenes/DraftScene.ts
@@ -14,17 +14,21 @@ export class DraftScene extends Phaser.Scene {
   private mapId: MapId = 'plains';
   private difficulty: DifficultyLevel = 'normal';
   private heroId: HeroId | null = null;
+  private randomSeed: number = 0;
+  private dailySeed: boolean = false;
 
   constructor() {
     super('DraftScene');
   }
 
-  init(data: { mode: MatchMode; faction: FactionId | null; map: MapId; difficulty?: DifficultyLevel; heroId?: HeroId }): void {
+  init(data: { mode: MatchMode; faction: FactionId | null; map: MapId; difficulty?: DifficultyLevel; heroId?: HeroId; randomSeed?: number; dailySeed?: boolean }): void {
     this.matchMode = data.mode;
     this.faction = data.faction;
     this.mapId = data.map;
     this.difficulty = data.difficulty || 'normal';
     this.heroId = data.heroId ?? null;
+    this.randomSeed = data.randomSeed ?? 0;
+    this.dailySeed = data.dailySeed ?? false;
   }
 
   create(): void {
@@ -85,6 +89,8 @@ export class DraftScene extends Phaser.Scene {
           modifier: mod,
           difficulty: this.difficulty,
           heroId: this.heroId,
+          randomSeed: this.randomSeed,
+          dailySeed: this.dailySeed,
         });
       });
     }
@@ -101,6 +107,8 @@ export class DraftScene extends Phaser.Scene {
           modifier: null,
           difficulty: this.difficulty,
           heroId: this.heroId,
+          randomSeed: this.randomSeed,
+          dailySeed: this.dailySeed,
         });
       })
       .on('pointerover', function(this: Phaser.GameObjects.Text) { this.setColor('#aaaaaa'); })

--- a/src/scenes/FactionSelectScene.ts
+++ b/src/scenes/FactionSelectScene.ts
@@ -11,15 +11,19 @@ export class FactionSelectScene extends Phaser.Scene {
   private matchMode: MatchMode = 'standard';
   private mapId: MapId = 'plains';
   private difficulty: DifficultyLevel = 'normal';
+  private randomSeed: number = 0;
+  private dailySeed: boolean = false;
 
   constructor() {
     super('FactionSelectScene');
   }
 
-  init(data: { mode: MatchMode; map?: MapId; difficulty?: DifficultyLevel }): void {
+  init(data: { mode: MatchMode; map?: MapId; difficulty?: DifficultyLevel; randomSeed?: number; dailySeed?: boolean }): void {
     this.matchMode = data.mode;
     this.mapId = data.map || 'plains';
     this.difficulty = data.difficulty || 'normal';
+    this.randomSeed = data.randomSeed ?? 0;
+    this.dailySeed = data.dailySeed ?? false;
   }
 
   create(): void {
@@ -119,9 +123,9 @@ export class FactionSelectScene extends Phaser.Scene {
       });
       zone.on('pointerdown', () => {
         if (this.matchMode === 'hero_defense') {
-          this.scene.start('HeroSelectScene', { mode: this.matchMode, faction: factionId, map: this.mapId, difficulty: this.difficulty });
+          this.scene.start('HeroSelectScene', { mode: this.matchMode, faction: factionId, map: this.mapId, difficulty: this.difficulty, randomSeed: this.randomSeed, dailySeed: this.dailySeed });
         } else {
-          this.scene.start('DraftScene', { mode: this.matchMode, faction: factionId, map: this.mapId, difficulty: this.difficulty });
+          this.scene.start('DraftScene', { mode: this.matchMode, faction: factionId, map: this.mapId, difficulty: this.difficulty, randomSeed: this.randomSeed, dailySeed: this.dailySeed });
         }
       });
     }

--- a/src/scenes/GameScene.ts
+++ b/src/scenes/GameScene.ts
@@ -16,7 +16,8 @@ import { UIOverlay } from '../systems/UIOverlay';
 import { getTowerType, TOWER_ORDER, TOWER_TYPES, getAllFactionTowerIds } from '../data/TowerTypes';
 import { FactionId, getFaction } from '../data/Factions';
 import { MatchMode, WaveDefinition, getWavesForMode } from '../data/WaveDefinitions';
-import { MapId, MAPS } from '../data/Maps';
+import { MapId, MAPS, MapDefinition } from '../data/Maps';
+import { generateRandomMap, getDailySeed } from '../data/MapGenerator';
 import { DifficultyLevel, DIFFICULTIES, DifficultyHints } from '../data/Difficulty';
 import { DraftModifier } from '../data/DraftModifiers';
 import { IncomeManager } from '../systems/IncomeManager';
@@ -115,6 +116,9 @@ export class GameScene extends Phaser.Scene {
   waves!: WaveDefinition[];
   matchMode: MatchMode = 'standard';
   mapId: MapId = 'plains';
+  randomSeed: number = 0;
+  dailySeed: boolean = false;
+  private generatedMapDef: MapDefinition | null = null;
   difficulty: DifficultyLevel = 'normal';
   difficultyHints!: DifficultyHints;
   faction: FactionId | null = null;
@@ -152,13 +156,16 @@ export class GameScene extends Phaser.Scene {
     super('GameScene');
   }
 
-  init(data: { mode?: MatchMode; faction?: FactionId | null; map?: MapId; modifier?: DraftModifier | null; difficulty?: DifficultyLevel; heroId?: HeroId }): void {
+  init(data: { mode?: MatchMode; faction?: FactionId | null; map?: MapId; modifier?: DraftModifier | null; difficulty?: DifficultyLevel; heroId?: HeroId; randomSeed?: number; dailySeed?: boolean }): void {
     this.matchMode = data.mode || 'standard';
     this.faction = data.faction ?? null;
     this.mapId = data.map || 'plains';
     this.modifier = data.modifier ?? null;
     this.difficulty = data.difficulty || 'normal';
     this.heroId = data.heroId ?? null;
+    this.dailySeed = data.dailySeed ?? false;
+    this.randomSeed = data.randomSeed ?? 0;
+    this.generatedMapDef = null;
     // Hero defense requires its own map (12-row grid)
     if (this.matchMode === 'hero_defense') {
       this.mapId = 'hero_plains';
@@ -174,6 +181,11 @@ export class GameScene extends Phaser.Scene {
     } else {
       this.activeTowerIds = TOWER_ORDER;
     }
+  }
+
+  /** Get the active map definition (generated for random, static otherwise) */
+  getMapDef(): MapDefinition {
+    return this.generatedMapDef ?? MAPS[this.mapId];
   }
 
   private rollRandomTowers(): string[] {
@@ -233,7 +245,25 @@ export class GameScene extends Phaser.Scene {
     }
 
     this.eventBus = new EventBus();
-    const mapDef = MAPS[this.mapId];
+
+    // Resolve map definition — generate for random maps
+    let mapDef: MapDefinition;
+    if (this.mapId === 'random') {
+      // For versus, use sharedSeed from VersusManager
+      const versusRef2 = this.registry.get('versus') as VersusManager | null;
+      if (versusRef2 && this.randomSeed === 0) {
+        this.randomSeed = versusRef2.sharedSeed;
+      }
+      // If still no seed, generate one (single player)
+      if (this.randomSeed === 0) {
+        this.randomSeed = this.dailySeed ? getDailySeed() : Math.floor(Math.random() * 999999999);
+      }
+      mapDef = generateRandomMap(this.randomSeed, this.difficulty);
+      this.generatedMapDef = mapDef;
+    } else {
+      mapDef = MAPS[this.mapId];
+    }
+
     const gridRows = this.layout.gridRows !== GRID_ROWS ? this.layout.gridRows : undefined;
     this.grid = new Grid(mapDef, gridRows);
     this.waves = getWavesForMode(this.matchMode);
@@ -269,6 +299,11 @@ export class GameScene extends Phaser.Scene {
 
     if (this.modifier && this.modifier.extraGold > 0) {
       this.economy.addGold(this.modifier.extraGold);
+    }
+
+    // Show seed for random maps
+    if (this.mapId === 'random' && this.randomSeed) {
+      this.ui.showSeed(this.randomSeed);
     }
 
     // Tower bar (starts deselected)
@@ -531,8 +566,7 @@ export class GameScene extends Phaser.Scene {
         this.drawOpponentView();
       });
       // Create opponent simulation
-      const mapDef = MAPS[this.mapId];
-      this.opponentSim = new OpponentSimulation(this.versus, mapDef, this.difficultyHints);
+      this.opponentSim = new OpponentSimulation(this.versus, this.getMapDef(), this.difficultyHints);
 
       this.eventLog.gameMessage('VERSUS MODE — sends go to opponent!');
       // Start initial 60s countdown for first wave
@@ -552,10 +586,10 @@ export class GameScene extends Phaser.Scene {
       this.towerOwners.clear();
 
       // Build zone restriction set for this player
-      const mapDef = MAPS[this.mapId];
-      if (mapDef.zones && mapDef.zones[this.circle.playerIndex]) {
+      const circleMapDef = this.getMapDef();
+      if (circleMapDef.zones && circleMapDef.zones[this.circle.playerIndex]) {
         this.circleMyZone = new Set(
-          mapDef.zones[this.circle.playerIndex].map(p => `${p.col},${p.row}`)
+          circleMapDef.zones[this.circle.playerIndex].map(p => `${p.col},${p.row}`)
         );
       }
 
@@ -1409,8 +1443,8 @@ export class GameScene extends Phaser.Scene {
   /** Draw zone tint overlay on the grid for circle co-op */
   private drawCircleZones(): void {
     if (!this.circle) return;
-    const mapDef = MAPS[this.mapId];
-    if (!mapDef.zones || !mapDef.zoneColors) return;
+    const zoneMapDef = this.getMapDef();
+    if (!zoneMapDef.zones || !zoneMapDef.zoneColors) return;
 
     if (!this.circleZoneOverlay) {
       this.circleZoneOverlay = this.add.graphics().setDepth(0.5);
@@ -1418,18 +1452,18 @@ export class GameScene extends Phaser.Scene {
     const g = this.circleZoneOverlay;
     g.clear();
 
-    for (let z = 0; z < mapDef.zones.length; z++) {
-      const color = mapDef.zoneColors[z];
+    for (let z = 0; z < zoneMapDef.zones.length; z++) {
+      const color = zoneMapDef.zoneColors[z];
       const isMyZone = z === this.circle.playerIndex;
       const alpha = isMyZone ? 0.12 : 0.06;
       g.fillStyle(color, alpha);
-      for (const cell of mapDef.zones[z]) {
+      for (const cell of zoneMapDef.zones[z]) {
         g.fillRect(gridLeftX(cell.col), gridY(cell.row) - TILE_SIZE / 2, TILE_SIZE, TILE_SIZE);
       }
       // Draw zone border for my zone
       if (isMyZone) {
         g.lineStyle(1, color, 0.3);
-        for (const cell of mapDef.zones[z]) {
+        for (const cell of zoneMapDef.zones[z]) {
           g.strokeRect(gridLeftX(cell.col), gridY(cell.row) - TILE_SIZE / 2, TILE_SIZE, TILE_SIZE);
         }
       }

--- a/src/scenes/HeroSelectScene.ts
+++ b/src/scenes/HeroSelectScene.ts
@@ -12,16 +12,20 @@ export class HeroSelectScene extends Phaser.Scene {
   private faction: FactionId | null = null;
   private mapId: MapId = 'hero_plains';
   private difficulty: DifficultyLevel = 'normal';
+  private randomSeed: number = 0;
+  private dailySeed: boolean = false;
 
   constructor() {
     super('HeroSelectScene');
   }
 
-  init(data: { mode: MatchMode; faction: FactionId | null; map?: MapId; difficulty?: DifficultyLevel }): void {
+  init(data: { mode: MatchMode; faction: FactionId | null; map?: MapId; difficulty?: DifficultyLevel; randomSeed?: number; dailySeed?: boolean }): void {
     this.matchMode = data.mode;
     this.faction = data.faction;
     this.mapId = data.map || 'hero_plains';
     this.difficulty = data.difficulty || 'normal';
+    this.randomSeed = data.randomSeed ?? 0;
+    this.dailySeed = data.dailySeed ?? false;
   }
 
   create(): void {
@@ -167,6 +171,8 @@ export class HeroSelectScene extends Phaser.Scene {
       mode: this.matchMode,
       map: this.mapId,
       difficulty: this.difficulty,
+      randomSeed: this.randomSeed,
+      dailySeed: this.dailySeed,
     }));
     backBtn.on('pointerover', () => backBtn.setColor('#ffffff'));
     backBtn.on('pointerout', () => backBtn.setColor('#888888'));
@@ -179,6 +185,8 @@ export class HeroSelectScene extends Phaser.Scene {
       map: this.mapId,
       difficulty: this.difficulty,
       heroId,
+      randomSeed: this.randomSeed,
+      dailySeed: this.dailySeed,
     });
   }
 }

--- a/src/scenes/LobbyScene.ts
+++ b/src/scenes/LobbyScene.ts
@@ -174,12 +174,18 @@ export class LobbyScene extends Phaser.Scene {
       const mapStartX = cx - (MAP_ORDER.length * 80) / 2;
       for (let i = 0; i < MAP_ORDER.length; i++) {
         const mid = MAP_ORDER[i];
+        const isRandom = mid === 'random';
+        const activeColor = isRandom ? '#ff44ff' : '#ffffff';
+        const inactiveColor = isRandom ? '#884488' : '#666666';
         const btn = this.add.text(mapStartX + i * 80 + 40, 212, MAPS[mid].name, {
-          fontSize: '13px', color: mid === this.selectedMap ? '#ffffff' : '#666666', fontFamily: 'monospace',
+          fontSize: '13px', color: mid === this.selectedMap ? activeColor : inactiveColor, fontFamily: 'monospace',
         }).setOrigin(0.5).setInteractive({ useHandCursor: true });
         btn.on('pointerdown', () => {
           this.selectedMap = mid;
-          mapBtns.forEach(b => b.btn.setColor(b.id === mid ? '#ffffff' : '#666666'));
+          mapBtns.forEach(b => {
+            const isR = b.id === 'random';
+            b.btn.setColor(b.id === mid ? (isR ? '#ff44ff' : '#ffffff') : (isR ? '#884488' : '#666666'));
+          });
         });
         mapBtns.push({ btn, id: mid });
       }

--- a/src/scenes/MenuScene.ts
+++ b/src/scenes/MenuScene.ts
@@ -3,6 +3,7 @@ import { getCanvasWidth, GAME_HEIGHT } from '../config';
 import { MatchMode } from '../data/WaveDefinitions';
 import { MapId, MAPS, MAP_ORDER } from '../data/Maps';
 import { DifficultyLevel } from '../data/Difficulty';
+import { getDailySeed } from '../data/MapGenerator';
 import { TowerSelectBar } from '../ui/TowerSelectBar';
 
 interface ModeCard {
@@ -15,6 +16,8 @@ interface ModeCard {
 export class MenuScene extends Phaser.Scene {
   private selectedMap: MapId = 'plains';
   private selectedDifficulty: DifficultyLevel = 'normal';
+  private dailySeed: boolean = true;
+  private dailyToggle: Phaser.GameObjects.Text | null = null;
   private mapButtons: { btn: Phaser.GameObjects.Graphics; id: MapId; x: number; y: number; w: number; h: number }[] = [];
   private diffButtons: { btn: Phaser.GameObjects.Graphics; id: DifficultyLevel; x: number; y: number; w: number; h: number }[] = [];
 
@@ -49,8 +52,9 @@ export class MenuScene extends Phaser.Scene {
       const btn = this.add.graphics();
       this.mapButtons.push({ btn, id: mapId, x, y, w: mapBtnW, h });
 
+      const nameColor = mapId === 'random' ? '#ff44ff' : '#ffffff';
       this.add.text(x + mapBtnW / 2, y + 10, map.name, {
-        fontSize: '13px', color: '#ffffff', fontFamily: 'monospace',
+        fontSize: '13px', color: nameColor, fontFamily: 'monospace',
       }).setOrigin(0.5);
 
       this.add.text(x + mapBtnW / 2, y + 28, map.description.substring(0, 24), {
@@ -61,13 +65,24 @@ export class MenuScene extends Phaser.Scene {
       zone.on('pointerdown', () => {
         this.selectedMap = mapId;
         this.drawMapButtons();
+        this.updateDailyToggle();
       });
     }
 
     this.drawMapButtons();
 
+    // Daily seed toggle (visible when Random map selected)
+    this.dailyToggle = this.add.text(cx, 154, '', {
+      fontSize: '9px', color: '#ff44ff', fontFamily: 'monospace',
+    }).setOrigin(0.5, 0).setInteractive({ useHandCursor: true });
+    this.dailyToggle.on('pointerdown', () => {
+      this.dailySeed = !this.dailySeed;
+      this.updateDailyToggle();
+    });
+    this.updateDailyToggle();
+
     // Difficulty selection
-    this.add.text(cx, 165, 'Difficulty', {
+    this.add.text(cx, 177, 'Difficulty', {
       fontSize: '14px', color: '#aaaaaa', fontFamily: 'monospace',
     }).setOrigin(0.5);
 
@@ -85,7 +100,7 @@ export class MenuScene extends Phaser.Scene {
     for (let i = 0; i < diffs.length; i++) {
       const d = diffs[i];
       const x = diffStartX + i * (diffBtnW + diffGap);
-      const y = 180;
+      const y = 192;
       const h = 28;
 
       const btn = this.add.graphics();
@@ -105,12 +120,18 @@ export class MenuScene extends Phaser.Scene {
     this.drawDiffButtons();
 
     // === Mode selection — 2x3 grid ===
-    this.add.text(cx, 222, 'Select Mode', {
+    this.add.text(cx, 234, 'Select Mode', {
       fontSize: '14px', color: '#aaaaaa', fontFamily: 'monospace',
     }).setOrigin(0.5);
 
     const goFaction = (mode: MatchMode) => {
-      this.scene.start('FactionSelectScene', { mode, map: this.selectedMap, difficulty: this.selectedDifficulty });
+      const seed = this.selectedMap === 'random'
+        ? (this.dailySeed ? getDailySeed() : Math.floor(Math.random() * 999999999))
+        : 0;
+      this.scene.start('FactionSelectScene', {
+        mode, map: this.selectedMap, difficulty: this.selectedDifficulty,
+        randomSeed: seed, dailySeed: this.dailySeed,
+      });
     };
 
     const modes: ModeCard[] = [
@@ -130,7 +151,7 @@ export class MenuScene extends Phaser.Scene {
     const gapY = 10;
     const gridW = cols * cardW + (cols - 1) * gapX;
     const gridStartX = cx - gridW / 2;
-    const gridStartY = 242;
+    const gridStartY = 254;
 
     for (let i = 0; i < modes.length; i++) {
       const m = modes[i];
@@ -214,17 +235,32 @@ export class MenuScene extends Phaser.Scene {
   private drawMapButtons(): void {
     for (const mb of this.mapButtons) {
       mb.btn.clear();
+      const isRandom = mb.id === 'random';
       if (mb.id === this.selectedMap) {
-        mb.btn.fillStyle(0x444444, 1);
+        mb.btn.fillStyle(isRandom ? 0x3a2a3a : 0x444444, 1);
         mb.btn.fillRect(mb.x, mb.y, mb.w, mb.h);
-        mb.btn.lineStyle(2, 0xffffff, 1);
+        mb.btn.lineStyle(2, isRandom ? 0xff44ff : 0xffffff, 1);
         mb.btn.strokeRect(mb.x, mb.y, mb.w, mb.h);
       } else {
         mb.btn.fillStyle(0x2a2a2a, 1);
         mb.btn.fillRect(mb.x, mb.y, mb.w, mb.h);
-        mb.btn.lineStyle(1, 0x555555, 0.6);
+        mb.btn.lineStyle(1, isRandom ? 0x884488 : 0x555555, 0.6);
         mb.btn.strokeRect(mb.x, mb.y, mb.w, mb.h);
       }
+    }
+  }
+
+  private updateDailyToggle(): void {
+    if (!this.dailyToggle) return;
+    if (this.selectedMap === 'random') {
+      const seed = getDailySeed();
+      this.dailyToggle.setVisible(true);
+      this.dailyToggle.setText(
+        this.dailySeed ? `[ Daily: ON — seed ${seed} ]` : '[ Daily: OFF — random seed ]'
+      );
+      this.dailyToggle.setColor(this.dailySeed ? '#ffaa44' : '#886688');
+    } else {
+      this.dailyToggle.setVisible(false);
     }
   }
 }

--- a/src/systems/UIOverlay.ts
+++ b/src/systems/UIOverlay.ts
@@ -9,6 +9,7 @@ export class UIOverlay {
   private speedText: Phaser.GameObjects.Text;
   private waveBtn: Phaser.GameObjects.Text;
   private speedBtn: Phaser.GameObjects.Text;
+  private seedText: Phaser.GameObjects.Text;
   private livesMode: 'lives' | 'base_hp';
   private onWaveStart: (() => void) | null = null;
   private onSpeedCycle: (() => void) | null = null;
@@ -42,6 +43,11 @@ export class UIOverlay {
     this.speedBtn.on('pointerdown', () => this.onSpeedCycle?.());
     this.speedBtn.on('pointerover', () => this.speedBtn.setAlpha(0.7));
     this.speedBtn.on('pointerout', () => this.speedBtn.setAlpha(1));
+
+    // Seed display (shown for random maps)
+    this.seedText = scene.add.text(getCanvasWidth() - 8, 4, '', {
+      fontSize: '10px', color: '#666666', fontFamily: 'monospace',
+    }).setDepth(30).setOrigin(1, 0).setVisible(false);
   }
 
   setCallbacks(onWaveStart: () => void, onSpeedCycle: () => void): void {
@@ -82,5 +88,9 @@ export class UIOverlay {
 
   setStatus(text: string): void {
     this.statusText.setText(text);
+  }
+
+  showSeed(seed: number): void {
+    this.seedText.setText(`Seed: ${seed}`).setVisible(true);
   }
 }


### PR DESCRIPTION
New "Random" map option in the map picker generates unique maps from a seed using chunk-based terrain features. Six layout templates (classic, dual_entry, siege, gauntlet, diagonal, corridor) define entry/exit positions, then terrain features (lakes, ridges, pillars, walls, islands, boulder clusters) are placed procedurally and validated via A* to guarantee all paths remain passable.

Key features:
- Difficulty-linked terrain density (Easy 8-10%, Insane 18-22%) with NoBuild zones and minimum path length constraints
- Daily seed toggle (ON by default) locks the same map for all players each day using seed = YYYYMMDD
- Versus integration via existing shared seed mechanism — both players generate identical maps from the same seed
- Seed displayed in top-right corner during gameplay
- Seeded PRNG (mulberry32) ensures deterministic generation

Seed data threaded through the full scene chain:
MenuScene → FactionSelectScene → HeroSelectScene → DraftScene → GameScene