### PR TITLE
Add mobile phone support for all game modes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## 2026-03-21
 
+### Mobile Phone Support
+- **Phone breakpoint** (<600px): New layout mode with reduced canvas (20 cols × 28px = 560px) for ~71% scale on phones instead of crushing 40%.
+- **GameControlBar**: Touch buttons for wave start, speed, pause + hero ability buttons (Q/W/E/R/T) with cooldown overlays. Replaces keyboard controls on phone.
+- **SidebarOverlay full-screen on phone**: Full canvas overlay instead of side panel, larger close button, darker scrim.
+- **TowerSelectBar phone sizing**: Smaller buttons (42px vs 52px), tighter padding, no hotkey numbers on phone.
+- **UIOverlay compact**: Tighter column spacing, hidden wave/speed buttons (control bar handles them), smaller font.
+- **HeroSelectScene carousel**: Single-card view on phone with prev/next navigation and dot indicators instead of 3-across.
+- **MenuScene responsive**: Map buttons in multi-row grid, 2-column mode cards, smaller difficulty buttons, dynamic Y offsets.
+- **FactionSelectScene responsive**: 3-column layout (vs 6), smaller cards (90px vs 140px), condensed text, tower list hidden on phone.
+- **Dynamic grid dimensions**: Grid cols/rows, game width, and layout config all respond to phone mode. Grid, Pathfinding, and InputManager use dynamic cols.
+
 ### Hero Defense Polish
 - **2% interest** on gold at end of each wave — rewards saving for bigger purchases.
 - **Stat accessories**: War Gauntlet (+15 dmg, 800g), Heart of Iron (+200 HP, 900g), Rapid Quiver (+25% AS, 1000g), Hawk Eye (+60px range, 1100g).

--- a/src/config.ts
+++ b/src/config.ts
@@ -8,7 +8,7 @@ export const GAME_HEIGHT = GRID_ROWS * TILE_SIZE;
 export const SIDEBAR_WIDTH = 360;
 
 // Dynamic grid offset — reads from ResponsiveManager at runtime
-// On desktop: offset = SIDEBAR_WIDTH (sidebar inline). On tablet: offset = 0 (sidebar overlay).
+// On desktop: offset = SIDEBAR_WIDTH (sidebar inline). On tablet/phone: offset = 0 (sidebar overlay).
 import { ResponsiveManager } from './systems/ResponsiveManager';
 
 /** @deprecated Use getGridOffsetX() for responsive layout */
@@ -20,6 +20,16 @@ export function getGridOffsetX(): number {
 
 export function getCanvasWidth(): number {
   return ResponsiveManager.canvasWidth();
+}
+
+/** Dynamic grid columns — reduced on phone */
+export function getGridCols(): number {
+  return ResponsiveManager.gridCols();
+}
+
+/** Dynamic game area width (grid only) */
+export function getGameWidth(): number {
+  return ResponsiveManager.gameWidth();
 }
 
 /** Static canvas width for desktop (kept for backward compat in non-game scenes) */

--- a/src/scenes/ChangelogScene.ts
+++ b/src/scenes/ChangelogScene.ts
@@ -5,6 +5,17 @@ import { TowerSelectBar } from '../ui/TowerSelectBar';
 // In-app changelog — recent changes shown to the player
 const CHANGELOG_ENTRIES = [
   {
+    version: 'v22 — Mobile Phone Support',
+    changes: [
+      'Phone layout (<600px): reduced canvas, touch controls, compact UI for all game modes',
+      'GameControlBar: touch buttons for wave/speed/pause + ability buttons (Q/W/E/R/T)',
+      'Full-screen sidebar overlay on phone with larger close button',
+      'Smaller tower buttons, responsive menu/faction/hero select scenes',
+      'Hero select: single-card carousel with prev/next navigation on phone',
+      'Dynamic grid dimensions: 20 cols on phone, 16 rows standard, 8 rows hero defense',
+    ],
+  },
+  {
     version: 'v21 — Hero Defense Overhaul',
     changes: [
       '11 heroes (up from 3): Paladin, Ranger, Berserker, Necromancer, Monk, Engineer, Duelist, Druid',

--- a/src/scenes/FactionSelectScene.ts
+++ b/src/scenes/FactionSelectScene.ts
@@ -33,11 +33,12 @@ export class FactionSelectScene extends Phaser.Scene {
       fontSize: '28px', color: '#ffffff', fontFamily: 'monospace',
     }).setOrigin(0.5);
 
-    const cardW = 140;
-    const cardH = 280;
-    const gap = 6;
+    const isPhone = getCanvasWidth() < 600;
+    const cardW = isPhone ? 90 : 140;
+    const cardH = isPhone ? 160 : 280;
+    const gap = isPhone ? 4 : 6;
     const factions = FACTION_ORDER;
-    const cols = 6;
+    const cols = isPhone ? 3 : 6;
     const rows = Math.ceil(factions.length / cols);
 
     for (let i = 0; i < factions.length; i++) {
@@ -62,23 +63,24 @@ export class FactionSelectScene extends Phaser.Scene {
       card.fillRect(x, y, cardW, 6);
 
       // Name
-      this.add.text(x + cardW / 2, y + 22, faction.name, {
-        fontSize: '16px', color: '#ffffff', fontFamily: 'monospace',
+      this.add.text(x + cardW / 2, y + (isPhone ? 16 : 22), faction.name, {
+        fontSize: isPhone ? '12px' : '16px', color: '#ffffff', fontFamily: 'monospace',
       }).setOrigin(0.5);
 
       // Tower count badge
       const tCount = faction.towerIds.length > 0 ? `${faction.towerIds.length} towers` : '6/wave';
-      this.add.text(x + cardW / 2, y + 40, tCount, {
-        fontSize: '10px', color: '#888888', fontFamily: 'monospace',
+      this.add.text(x + cardW / 2, y + (isPhone ? 30 : 40), tCount, {
+        fontSize: isPhone ? '9px' : '10px', color: '#888888', fontFamily: 'monospace',
       }).setOrigin(0.5);
 
       // Description
-      this.add.text(x + 8, y + 55, faction.description, {
-        fontSize: '10px', color: '#aaaaaa', fontFamily: 'monospace',
-        wordWrap: { width: cardW - 16 },
+      this.add.text(x + 6, y + (isPhone ? 42 : 55), faction.description, {
+        fontSize: isPhone ? '8px' : '10px', color: '#aaaaaa', fontFamily: 'monospace',
+        wordWrap: { width: cardW - 12 },
       });
 
-      // Tower list
+      // Tower list (skip on phone — cards too small)
+      if (isPhone) { /* skip tower list */ } else {
       const towerY = y + 100;
       if (factionId === 'random') {
         this.add.text(x + 8, towerY, 'Each wave: 6 random\ntowers from all factions.\nBought towers persist.\nAdapt to what you get.', {
@@ -100,6 +102,7 @@ export class FactionSelectScene extends Phaser.Scene {
           ty += 13;
         }
       }
+      } // end if !isPhone tower list
 
       // Click zone
       const zone = this.add.zone(x + cardW / 2, y + cardH / 2, cardW, cardH).setInteractive({ useHandCursor: true });

--- a/src/scenes/GameScene.ts
+++ b/src/scenes/GameScene.ts
@@ -1,7 +1,7 @@
 import Phaser from 'phaser';
 import {
   TILE_SIZE, GRID_COLS, GRID_ROWS, GAME_WIDTH, GAME_HEIGHT,
-  SIDEBAR_WIDTH, getGridOffsetX, getCanvasWidth,
+  SIDEBAR_WIDTH, getGridOffsetX, getCanvasWidth, getGameWidth, getGridCols,
   COLOR_GROUND, COLOR_GRID_LINE, COLOR_ENTRY, COLOR_EXIT,
   COLOR_HOVER_VALID, COLOR_HOVER_INVALID, STARTING_LIVES,
   gridX, gridY, gridLeftX, pixelToCol, setGridOffsetY,
@@ -57,6 +57,7 @@ import { UpdateContext } from '../systems/traits/Trait';
 import { GameOverData } from './GameOverScene';
 import { Creep } from '../entities/Creep';
 import { Tower } from '../entities/Tower';
+import { GameControlBar } from '../ui/GameControlBar';
 
 type SelectionMode = 'build' | 'inspect' | 'inspect_creep' | 'link' | 'none';
 
@@ -98,6 +99,7 @@ export class GameScene extends Phaser.Scene {
   viewingOpponent: boolean = false;
   arenaManager: ArenaManager | null = null;
   abilitySystem: AbilitySystem | null = null;
+  private controlBar: GameControlBar | null = null;
   heroId: HeroId | null = null;
   layout!: LayoutConfig;
   gridOffsetY: number = 0;
@@ -359,7 +361,7 @@ export class GameScene extends Phaser.Scene {
     if (this.matchMode === 'hero_defense' && this.heroId) {
       const heroType = HERO_TYPES[this.heroId];
       this.arenaManager = new ArenaManager(
-        this, heroType, GAME_WIDTH, this.layout.arenaHeight,
+        this, heroType, getGameWidth(), this.layout.arenaHeight,
         this.economy, this.eventLog, 10000,
       );
       this.abilitySystem = new AbilitySystem(this);
@@ -507,6 +509,23 @@ export class GameScene extends Phaser.Scene {
       this.inputMgr.onKey('E', () => this.arenaManager!.handleAbilityKey(2));
       this.inputMgr.onKey('R', () => this.arenaManager!.handleAbilityKey(3));
       this.inputMgr.onKey('T', () => this.arenaManager!.handleAccessoryKey());
+    }
+
+    // Phone: touch control bar with wave/speed/pause + ability buttons
+    if (ResponsiveManager.isPhone()) {
+      const controlBarY = this.layout.totalHeight + 28; // below status bar
+      this.controlBar = new GameControlBar(this, controlBarY, this.arenaManager);
+      this.controlBar.setCallbacks(
+        () => {
+          if (this.betweenWaves && this.currentWave < this.waves.length) {
+            if (this.circle) this.circle.voteReady();
+            else if (this.versus) this.versus.voteReady();
+            else this.startWave();
+          }
+        },
+        () => this.cycleSpeed(),
+        () => this.togglePause(),
+      );
     }
 
     // Versus mode setup
@@ -1002,6 +1021,12 @@ export class GameScene extends Phaser.Scene {
     // Mode-specific per-frame update (essence ticking, arena, etc.)
     this.gameMode.update(delta);
 
+    // Phone control bar
+    if (this.controlBar) {
+      this.controlBar.setState(this.waveActive, this.betweenWaves, this.currentWave < this.waves.length, this.gameSpeed);
+      this.controlBar.update();
+    }
+
     // Ability VFX
     if (this.abilitySystem) this.abilitySystem.update(delta);
 
@@ -1198,7 +1223,8 @@ export class GameScene extends Phaser.Scene {
   private showPauseMenu(): void {
     if (this.pauseOverlay) return;
 
-    const cx = getGridOffsetX() + GAME_WIDTH / 2;
+    const gw = getGameWidth();
+    const cx = getGridOffsetX() + gw / 2;
     const cy = GAME_HEIGHT / 2;
 
     this.pauseOverlay = this.add.container(0, 0).setDepth(50);
@@ -1206,7 +1232,7 @@ export class GameScene extends Phaser.Scene {
     // Dim overlay
     const dim = this.add.graphics();
     dim.fillStyle(0x000000, 0.6);
-    dim.fillRect(getGridOffsetX(), 0, GAME_WIDTH, GAME_HEIGHT);
+    dim.fillRect(getGridOffsetX(), 0, gw, GAME_HEIGHT);
     this.pauseOverlay.add(dim);
 
     // Panel
@@ -1287,22 +1313,24 @@ export class GameScene extends Phaser.Scene {
     const rows = this.grid.rows;
     const gridH = rows * TILE_SIZE;
 
+    const cols = getGridCols();
+    const gw = getGameWidth();
+
     g.fillStyle(COLOR_GROUND, 1);
-    g.fillRect(getGridOffsetX(), oY, GAME_WIDTH, gridH);
+    g.fillRect(getGridOffsetX(), oY, gw, gridH);
 
     g.lineStyle(1, COLOR_GRID_LINE, 0.3);
-    for (let col = 0; col <= GRID_COLS; col++) {
+    for (let col = 0; col <= cols; col++) {
       g.lineBetween(gridLeftX(col), oY, gridLeftX(col), oY + gridH);
     }
     for (let row = 0; row <= rows; row++) {
-      // gridY already includes offset, but here we draw raw grid lines
-      g.lineBetween(getGridOffsetX(), oY + row * TILE_SIZE, getGridOffsetX() + GAME_WIDTH, oY + row * TILE_SIZE);
+      g.lineBetween(getGridOffsetX(), oY + row * TILE_SIZE, getGridOffsetX() + gw, oY + row * TILE_SIZE);
     }
 
     // Blocked terrain — use gridY-based coords (includes offset)
     g.fillStyle(0x1a1a1a, 1);
     for (let row = 0; row < rows; row++) {
-      for (let col = 0; col < GRID_COLS; col++) {
+      for (let col = 0; col < cols; col++) {
         const cell = this.grid.cells[row][col];
         const cellY = oY + row * TILE_SIZE;
         if (cell === CellType.Blocked) {
@@ -1352,7 +1380,7 @@ export class GameScene extends Phaser.Scene {
 
     // Dim the grid background
     this.opponentOverlay.fillStyle(0x000000, 0.3);
-    this.opponentOverlay.fillRect(getGridOffsetX(), 0, GAME_WIDTH, GAME_HEIGHT);
+    this.opponentOverlay.fillRect(getGridOffsetX(), 0, getGameWidth(), GAME_HEIGHT);
 
     // Draw opponent towers as colored squares on the main grid
     for (const t of this.versus.opponentTowers) {

--- a/src/scenes/HeroSelectScene.ts
+++ b/src/scenes/HeroSelectScene.ts
@@ -6,6 +6,7 @@ import { FactionId, FACTIONS } from '../data/Factions';
 import { MapId } from '../data/Maps';
 import { DifficultyLevel } from '../data/Difficulty';
 import { TowerSelectBar } from '../ui/TowerSelectBar';
+import { ResponsiveManager } from '../systems/ResponsiveManager';
 
 /** Pick N random unique elements from an array */
 function pickRandom<T>(arr: T[], count: number): T[] {
@@ -24,6 +25,8 @@ export class HeroSelectScene extends Phaser.Scene {
   private difficulty: DifficultyLevel = 'normal';
   private randomSeed: number = 0;
   private dailySeed: boolean = false;
+  private phoneCardIndex: number = 0;
+  private phoneOffered: HeroId[] = [];
 
   constructor() {
     super('HeroSelectScene');
@@ -65,6 +68,15 @@ export class HeroSelectScene extends Phaser.Scene {
       offered = [factionHero, ...randomOthers];
     } else {
       offered = pickRandom(HERO_ORDER, 3);
+    }
+
+    const isPhone = ResponsiveManager.isPhone();
+
+    if (isPhone) {
+      this.phoneOffered = offered;
+      this.phoneCardIndex = 0;
+      this.buildPhoneCard(cx);
+      return;
     }
 
     const cardW = 260;
@@ -190,6 +202,113 @@ export class HeroSelectScene extends Phaser.Scene {
     }));
     backBtn.on('pointerover', () => backBtn.setColor('#ffffff'));
     backBtn.on('pointerout', () => backBtn.setColor('#888888'));
+  }
+
+  private buildPhoneCard(cx: number): void {
+    const cw = getCanvasWidth();
+    const heroId = this.phoneOffered[this.phoneCardIndex];
+    const hero = HERO_TYPES[heroId];
+    const factionHero = this.faction && this.faction !== 'random'
+      ? getHeroForFaction(this.faction) : null;
+    const isFactionHero = heroId === factionHero;
+
+    const cardW = cw - 40;
+    const cardH = 380;
+    const x = 20;
+    const y = 80;
+
+    const card = this.add.graphics();
+    this.drawCard(card, x, y, cardW, cardH, hero.color, false);
+    this.drawDiamond(card, x + cardW / 2, y + 30, 14, hero.color);
+
+    // Faction tag
+    const factionName = FACTIONS[hero.faction as FactionId]?.name ?? hero.faction;
+    this.add.text(x + cardW / 2, y + 50, factionName.toUpperCase(), {
+      fontSize: '9px', color: isFactionHero ? '#ffaa44' : '#555555', fontFamily: 'monospace',
+    }).setOrigin(0.5);
+
+    // Name
+    this.add.text(x + cardW / 2, y + 62, hero.name, {
+      fontSize: '18px', color: '#ffffff', fontFamily: 'monospace',
+    }).setOrigin(0.5);
+
+    // Description
+    this.add.text(x + cardW / 2, y + 82, hero.description, {
+      fontSize: '10px', color: '#aaaaaa', fontFamily: 'monospace',
+      wordWrap: { width: cardW - 20 }, align: 'center',
+    }).setOrigin(0.5, 0);
+
+    // Stats (compact)
+    const statsY = y + 110;
+    const lines = [
+      `HP:${hero.hp}  DMG:${hero.damage}  AS:${hero.attackSpeed}/s`,
+      `Range:${hero.attackRange <= 50 ? 'Melee' : hero.attackRange + 'px'}  SPD:${hero.moveSpeed}${hero.baseArmor ? '  ARM:' + hero.baseArmor : ''}`,
+    ];
+    this.add.text(x + 12, statsY, lines.join('\n'), {
+      fontSize: '11px', color: '#cccccc', fontFamily: 'monospace', lineSpacing: 4,
+    });
+
+    // Abilities (compact)
+    let ay = statsY + 38;
+    for (const ab of hero.abilities) {
+      this.add.text(x + 12, ay, `[${ab.key}] ${ab.name} — ${ab.description} (${ab.cooldown}s)`, {
+        fontSize: '10px', color: '#ffffff', fontFamily: 'monospace',
+        wordWrap: { width: cardW - 24 },
+      });
+      ay += 24;
+    }
+    if (hero.ultimate) {
+      this.add.text(x + 12, ay, `[R] ${hero.ultimate.name} — ${hero.ultimate.description} (${hero.ultimate.cooldown}s)`, {
+        fontSize: '10px', color: '#cc66ff', fontFamily: 'monospace',
+        wordWrap: { width: cardW - 24 },
+      });
+    }
+
+    // Select button
+    const selBtn = this.add.text(x + cardW / 2, y + cardH - 30, '[ SELECT ]', {
+      fontSize: '16px', color: '#44ff44', fontFamily: 'monospace',
+      backgroundColor: '#1a2a1a', padding: { x: 20, y: 6 },
+    }).setOrigin(0.5).setInteractive({ useHandCursor: true });
+    selBtn.on('pointerdown', () => this.selectHero(heroId));
+    selBtn.on('pointerover', () => selBtn.setColor('#ffffff'));
+    selBtn.on('pointerout', () => selBtn.setColor('#44ff44'));
+
+    // Prev/Next arrows
+    const totalH = GAME_HEIGHT + 28 + TowerSelectBar.BAR_HEIGHT;
+    if (this.phoneOffered.length > 1) {
+      const prevBtn = this.add.text(20, y + cardH / 2, '<', {
+        fontSize: '30px', color: '#888888', fontFamily: 'monospace',
+      }).setOrigin(0.5).setInteractive({ useHandCursor: true });
+      prevBtn.on('pointerdown', () => {
+        this.phoneCardIndex = (this.phoneCardIndex - 1 + this.phoneOffered.length) % this.phoneOffered.length;
+        this.scene.restart();
+      });
+
+      const nextBtn = this.add.text(cw - 20, y + cardH / 2, '>', {
+        fontSize: '30px', color: '#888888', fontFamily: 'monospace',
+      }).setOrigin(0.5).setInteractive({ useHandCursor: true });
+      nextBtn.on('pointerdown', () => {
+        this.phoneCardIndex = (this.phoneCardIndex + 1) % this.phoneOffered.length;
+        this.scene.restart();
+      });
+
+      // Dots indicator
+      for (let i = 0; i < this.phoneOffered.length; i++) {
+        const dotColor = i === this.phoneCardIndex ? '#ffffff' : '#444444';
+        this.add.text(cx - 10 + i * 15, totalH - 30, '●', {
+          fontSize: '12px', color: dotColor, fontFamily: 'monospace',
+        }).setOrigin(0.5);
+      }
+    }
+
+    // Back button
+    const backBtn = this.add.text(50, 25, '[ Back ]', {
+      fontSize: '14px', color: '#888888', fontFamily: 'monospace',
+    }).setInteractive({ useHandCursor: true });
+    backBtn.on('pointerdown', () => this.scene.start('FactionSelectScene', {
+      mode: this.matchMode, map: this.mapId, difficulty: this.difficulty,
+      randomSeed: this.randomSeed, dailySeed: this.dailySeed,
+    }));
   }
 
   private drawCard(g: Phaser.GameObjects.Graphics, x: number, y: number, w: number, h: number, color: number, hovered: boolean): void {

--- a/src/scenes/MenuScene.ts
+++ b/src/scenes/MenuScene.ts
@@ -5,6 +5,7 @@ import { MapId, MAPS, MAP_ORDER } from '../data/Maps';
 import { DifficultyLevel } from '../data/Difficulty';
 import { getDailySeed } from '../data/MapGenerator';
 import { TowerSelectBar } from '../ui/TowerSelectBar';
+import { ResponsiveManager } from '../systems/ResponsiveManager';
 
 interface ModeCard {
   label: string;
@@ -37,16 +38,20 @@ export class MenuScene extends Phaser.Scene {
       fontSize: '14px', color: '#aaaaaa', fontFamily: 'monospace',
     }).setOrigin(0.5);
 
-    const mapBtnW = 140;
-    const mapGap = 10;
-    const mapTotalW = MAP_ORDER.length * mapBtnW + (MAP_ORDER.length - 1) * mapGap;
+    const isPhone = ResponsiveManager.isPhone();
+    const mapBtnW = isPhone ? 100 : 140;
+    const mapGap = isPhone ? 4 : 10;
+    const cols = isPhone ? Math.floor((getCanvasWidth() - 20) / (mapBtnW + mapGap)) : MAP_ORDER.length;
+    const mapTotalW = Math.min(MAP_ORDER.length, cols) * mapBtnW + (Math.min(MAP_ORDER.length, cols) - 1) * mapGap;
     const mapStartX = cx - mapTotalW / 2;
 
     for (let i = 0; i < MAP_ORDER.length; i++) {
       const mapId = MAP_ORDER[i];
       const map = MAPS[mapId];
-      const x = mapStartX + i * (mapBtnW + mapGap);
-      const y = 112;
+      const col = i % cols;
+      const row = Math.floor(i / cols);
+      const x = mapStartX + col * (mapBtnW + mapGap);
+      const y = 112 + row * 48;
       const h = 40;
 
       const btn = this.add.graphics();
@@ -72,7 +77,11 @@ export class MenuScene extends Phaser.Scene {
     this.drawMapButtons();
 
     // Daily seed toggle (visible when Random map selected)
-    this.dailyToggle = this.add.text(cx, 154, '', {
+    // Extra Y offset for phone multi-row maps
+    const mapRows = Math.ceil(MAP_ORDER.length / cols);
+    const phoneYShift = isPhone ? (mapRows - 1) * 48 : 0;
+
+    this.dailyToggle = this.add.text(cx, 154 + phoneYShift, '', {
       fontSize: '9px', color: '#ff44ff', fontFamily: 'monospace',
     }).setOrigin(0.5, 0).setInteractive({ useHandCursor: true });
     this.dailyToggle.on('pointerdown', () => {
@@ -82,7 +91,7 @@ export class MenuScene extends Phaser.Scene {
     this.updateDailyToggle();
 
     // Difficulty selection
-    this.add.text(cx, 177, 'Difficulty', {
+    this.add.text(cx, 177 + phoneYShift, 'Difficulty', {
       fontSize: '14px', color: '#aaaaaa', fontFamily: 'monospace',
     }).setOrigin(0.5);
 
@@ -92,15 +101,15 @@ export class MenuScene extends Phaser.Scene {
       { id: 'hard', label: 'Hard', color: '#ff4444' },
       { id: 'insane', label: 'Insane', color: '#ff00ff' },
     ];
-    const diffBtnW = 90;
-    const diffGap = 8;
+    const diffBtnW = isPhone ? 60 : 90;
+    const diffGap = isPhone ? 4 : 8;
     const diffTotalW = diffs.length * diffBtnW + (diffs.length - 1) * diffGap;
     const diffStartX = cx - diffTotalW / 2;
 
     for (let i = 0; i < diffs.length; i++) {
       const d = diffs[i];
       const x = diffStartX + i * (diffBtnW + diffGap);
-      const y = 192;
+      const y = 192 + phoneYShift;
       const h = 28;
 
       const btn = this.add.graphics();
@@ -120,7 +129,7 @@ export class MenuScene extends Phaser.Scene {
     this.drawDiffButtons();
 
     // === Mode selection — 2x3 grid ===
-    this.add.text(cx, 234, 'Select Mode', {
+    this.add.text(cx, 234 + phoneYShift, 'Select Mode', {
       fontSize: '14px', color: '#aaaaaa', fontFamily: 'monospace',
     }).setOrigin(0.5);
 
@@ -144,21 +153,21 @@ export class MenuScene extends Phaser.Scene {
       { label: 'Circle Co-op',     desc: '2-4 players — shared map',        accent: 0x44aaff, action: () => this.scene.start('CircleLobbyScene') },
     ];
 
-    const cols = 3;
-    const cardW = 200;
-    const cardH = 56;
-    const gapX = 12;
-    const gapY = 10;
-    const gridW = cols * cardW + (cols - 1) * gapX;
+    const modeCols = isPhone ? 2 : 3;
+    const cardW = isPhone ? Math.floor((getCanvasWidth() - 30) / modeCols - 6) : 200;
+    const cardH = isPhone ? 48 : 56;
+    const gapX = isPhone ? 6 : 12;
+    const gapY = isPhone ? 6 : 10;
+    const gridW = modeCols * cardW + (modeCols - 1) * gapX;
     const gridStartX = cx - gridW / 2;
-    const gridStartY = 254;
+    const gridStartY = 254 + phoneYShift;
 
     for (let i = 0; i < modes.length; i++) {
       const m = modes[i];
-      const col = i % cols;
-      const row = Math.floor(i / cols);
-      const x = gridStartX + col * (cardW + gapX);
-      const y = gridStartY + row * (cardH + gapY);
+      const mCol = i % modeCols;
+      const mRow = Math.floor(i / modeCols);
+      const x = gridStartX + mCol * (cardW + gapX);
+      const y = gridStartY + mRow * (cardH + gapY);
 
       const card = this.add.graphics();
       const drawCard = (hover: boolean) => {
@@ -173,12 +182,13 @@ export class MenuScene extends Phaser.Scene {
       };
       drawCard(false);
 
-      this.add.text(x + 14, y + 12, m.label, {
-        fontSize: '15px', color: '#ffffff', fontFamily: 'monospace',
+      this.add.text(x + 10, y + (isPhone ? 8 : 12), m.label, {
+        fontSize: isPhone ? '13px' : '15px', color: '#ffffff', fontFamily: 'monospace',
       });
 
-      this.add.text(x + 14, y + 34, m.desc, {
-        fontSize: '10px', color: '#888888', fontFamily: 'monospace',
+      this.add.text(x + 10, y + (isPhone ? 26 : 34), m.desc, {
+        fontSize: isPhone ? '8px' : '10px', color: '#888888', fontFamily: 'monospace',
+        wordWrap: { width: cardW - 16 },
       });
 
       const zone = this.add.zone(x + cardW / 2, y + cardH / 2, cardW, cardH).setInteractive({ useHandCursor: true });
@@ -188,12 +198,13 @@ export class MenuScene extends Phaser.Scene {
     }
 
     // Multiplayer note
-    this.add.text(cx, gridStartY + 3 * (cardH + gapY) - 2, 'Multiplayer modes use P2P WebRTC — no server required', {
+    const modeRows = Math.ceil(modes.length / modeCols);
+    this.add.text(cx, gridStartY + modeRows * (cardH + gapY) - 2, 'Multiplayer modes use P2P WebRTC — no server required', {
       fontSize: '10px', color: '#555555', fontFamily: 'monospace',
     }).setOrigin(0.5);
 
     // Encyclopedia + Changelog buttons
-    const bottomRowY = gridStartY + 3 * (cardH + gapY) + 18;
+    const bottomRowY = gridStartY + modeRows * (cardH + gapY) + 18;
     const encBtn = this.add.text(cx - 120, bottomRowY, '[ Encyclopedia ]', {
       fontSize: '13px', color: '#88aacc', fontFamily: 'monospace',
     }).setOrigin(0.5).setInteractive({ useHandCursor: true });

--- a/src/systems/Grid.ts
+++ b/src/systems/Grid.ts
@@ -1,4 +1,4 @@
-import { GRID_COLS, GRID_ROWS } from '../config';
+import { GRID_COLS, GRID_ROWS, getGridCols } from '../config';
 import { MapDefinition } from '../data/Maps';
 
 export enum CellType {
@@ -17,11 +17,13 @@ export class Grid {
   entries: { col: number; row: number }[];
   exits: { col: number; row: number }[];
   readonly rows: number;
+  readonly cols: number;
 
-  constructor(mapDef?: MapDefinition, rows?: number) {
+  constructor(mapDef?: MapDefinition, rows?: number, cols?: number) {
     this.rows = rows ?? GRID_ROWS;
+    this.cols = cols ?? getGridCols();
     this.cells = Array.from({ length: this.rows }, () =>
-      Array(GRID_COLS).fill(CellType.Empty)
+      Array(this.cols).fill(CellType.Empty)
     );
 
     if (mapDef) {
@@ -31,29 +33,29 @@ export class Grid {
       this.exit = mapDef.exits[0];
 
       for (const e of mapDef.entries) {
-        if (e.row >= 0 && e.row < this.rows && e.col >= 0 && e.col < GRID_COLS) {
+        if (e.row >= 0 && e.row < this.rows && e.col >= 0 && e.col < this.cols) {
           this.cells[e.row][e.col] = CellType.Entry;
         }
       }
       for (const e of mapDef.exits) {
-        if (e.row >= 0 && e.row < this.rows && e.col >= 0 && e.col < GRID_COLS) {
+        if (e.row >= 0 && e.row < this.rows && e.col >= 0 && e.col < this.cols) {
           this.cells[e.row][e.col] = CellType.Exit;
         }
       }
       for (const b of mapDef.blocked) {
-        if (b.row >= 0 && b.row < this.rows && b.col >= 0 && b.col < GRID_COLS) {
+        if (b.row >= 0 && b.row < this.rows && b.col >= 0 && b.col < this.cols) {
           this.cells[b.row][b.col] = CellType.Blocked;
         }
       }
       for (const b of (mapDef.noBuild || [])) {
-        if (b.row >= 0 && b.row < this.rows && b.col >= 0 && b.col < GRID_COLS) {
+        if (b.row >= 0 && b.row < this.rows && b.col >= 0 && b.col < this.cols) {
           this.cells[b.row][b.col] = CellType.NoBuild;
         }
       }
     } else {
       // Default: plains
       this.entry = { col: 0, row: Math.floor(this.rows / 2) };
-      this.exit = { col: GRID_COLS - 1, row: Math.floor(this.rows / 2) };
+      this.exit = { col: this.cols - 1, row: Math.floor(this.rows / 2) };
       this.entries = [this.entry];
       this.exits = [this.exit];
 
@@ -63,14 +65,14 @@ export class Grid {
   }
 
   isWalkable(col: number, row: number): boolean {
-    if (col < 0 || col >= GRID_COLS || row < 0 || row >= this.rows) return false;
+    if (col < 0 || col >= this.cols || row < 0 || row >= this.rows) return false;
     const cell = this.cells[row][col];
     return cell !== CellType.Tower && cell !== CellType.Blocked;
     // NoBuild IS walkable (creeps can walk through, towers can't be placed)
   }
 
   canPlaceTower(col: number, row: number): boolean {
-    if (col < 0 || col >= GRID_COLS || row < 0 || row >= this.rows) return false;
+    if (col < 0 || col >= this.cols || row < 0 || row >= this.rows) return false;
     return this.cells[row][col] === CellType.Empty;
     // NoBuild, Blocked, Tower, Entry, Exit all return false
   }

--- a/src/systems/InputManager.ts
+++ b/src/systems/InputManager.ts
@@ -1,4 +1,4 @@
-import { GRID_COLS, GRID_ROWS, pixelToCol, pixelToRow } from '../config';
+import { GRID_COLS, GRID_ROWS, pixelToCol, pixelToRow, getGridCols } from '../config';
 import { EventBus } from './EventBus';
 
 export interface GridCoord {
@@ -140,7 +140,7 @@ export class InputManager {
   private pointerToGrid(pointer: Phaser.Input.Pointer): GridCoord | null {
     const col = pixelToCol(pointer.x);
     const row = pixelToRow(pointer.y); // pixelToRow already accounts for _gridOffsetY
-    if (col < 0 || col >= GRID_COLS || row < 0 || row >= this.gridRows) return null;
+    if (col < 0 || col >= getGridCols() || row < 0 || row >= this.gridRows) return null;
     return { col, row };
   }
 }

--- a/src/systems/LayoutConfig.ts
+++ b/src/systems/LayoutConfig.ts
@@ -1,5 +1,6 @@
 import { GRID_ROWS, TILE_SIZE } from '../config';
 import { MatchMode } from '../data/WaveDefinitions';
+import { ResponsiveManager } from './ResponsiveManager';
 
 export interface LayoutConfig {
   gridRows: number;
@@ -10,9 +11,11 @@ export interface LayoutConfig {
 
 /** Returns layout dimensions for a given match mode */
 export function getLayout(mode: MatchMode): LayoutConfig {
+  const isPhone = ResponsiveManager.isPhone();
+
   if (mode === 'hero_defense') {
-    const gridRows = 12;
-    const arenaHeight = 400;
+    const gridRows = isPhone ? 8 : 12;
+    const arenaHeight = isPhone ? 200 : 400;
     return {
       gridRows,
       gridOffsetY: arenaHeight,
@@ -21,11 +24,12 @@ export function getLayout(mode: MatchMode): LayoutConfig {
     };
   }
 
-  // Standard / Sprint / Marathon / Battle — full 26-row grid, no arena
+  // Standard / Sprint / Marathon / Battle / Circle
+  const gridRows = isPhone ? 16 : GRID_ROWS;
   return {
-    gridRows: GRID_ROWS,
+    gridRows,
     gridOffsetY: 0,
     arenaHeight: 0,
-    totalHeight: GRID_ROWS * TILE_SIZE,
+    totalHeight: gridRows * TILE_SIZE,
   };
 }

--- a/src/systems/Pathfinding.ts
+++ b/src/systems/Pathfinding.ts
@@ -67,7 +67,7 @@ export function findPath(grid: Grid, start?: PathPoint, end?: PathPoint): PathPo
       const nc = current.col + dc;
       const nr = current.row + dr;
 
-      if (nc < 0 || nc >= GRID_COLS || nr < 0 || nr >= grid.rows) continue;
+      if (nc < 0 || nc >= grid.cols || nr < 0 || nr >= grid.rows) continue;
       if (!grid.isWalkable(nc, nr)) continue;
       if (closed.has(key(nc, nr))) continue;
 

--- a/src/systems/ResponsiveManager.ts
+++ b/src/systems/ResponsiveManager.ts
@@ -1,11 +1,15 @@
-import { SIDEBAR_WIDTH, GAME_WIDTH, GAME_HEIGHT } from '../config';
+import { SIDEBAR_WIDTH, GAME_WIDTH, GAME_HEIGHT, TILE_SIZE } from '../config';
 import { TowerSelectBar } from '../ui/TowerSelectBar';
 
 const TABLET_BREAKPOINT = 1200;
+const PHONE_BREAKPOINT = 600;
 
-export type LayoutMode = 'desktop' | 'tablet';
+export type LayoutMode = 'desktop' | 'tablet' | 'phone';
 
 type LayoutChangeCallback = (mode: LayoutMode) => void;
+
+/** Phone grid: fewer columns so the canvas is smaller and scales better */
+const PHONE_GRID_COLS = 20;
 
 class ResponsiveManagerClass {
   private _mode: LayoutMode = 'desktop';
@@ -26,23 +30,37 @@ class ResponsiveManagerClass {
   }
 
   private detectMode(): LayoutMode {
-    return window.innerWidth < TABLET_BREAKPOINT ? 'tablet' : 'desktop';
+    const w = window.innerWidth;
+    if (w < PHONE_BREAKPOINT) return 'phone';
+    if (w < TABLET_BREAKPOINT) return 'tablet';
+    return 'desktop';
   }
 
   get mode(): LayoutMode { return this._mode; }
 
-  isTablet(): boolean { return this._mode === 'tablet'; }
+  isPhone(): boolean { return this._mode === 'phone'; }
+  isTablet(): boolean { return this._mode === 'tablet' || this._mode === 'phone'; }
 
   sidebarInline(): boolean { return this._mode === 'desktop'; }
 
-  /** Grid offset X: on desktop the sidebar is inline, on tablet grid uses full width */
+  /** Grid columns: reduced on phone for a smaller canvas */
+  gridCols(): number {
+    return this._mode === 'phone' ? PHONE_GRID_COLS : 36;
+  }
+
+  /** Game area width (grid only, no sidebar) */
+  gameWidth(): number {
+    return this.gridCols() * TILE_SIZE;
+  }
+
+  /** Grid offset X: on desktop the sidebar is inline, on tablet/phone grid uses full width */
   gridOffsetX(): number {
     return this._mode === 'desktop' ? SIDEBAR_WIDTH : 0;
   }
 
-  /** Canvas width: desktop includes inline sidebar, tablet is just the game area */
+  /** Canvas width: desktop includes inline sidebar, tablet/phone is just the game area */
   canvasWidth(): number {
-    return this._mode === 'desktop' ? SIDEBAR_WIDTH + GAME_WIDTH : GAME_WIDTH;
+    return this._mode === 'desktop' ? SIDEBAR_WIDTH + GAME_WIDTH : this.gameWidth();
   }
 
   /** Full canvas height including status bar and tower select bar */

--- a/src/systems/UIOverlay.ts
+++ b/src/systems/UIOverlay.ts
@@ -1,4 +1,5 @@
 import { GAME_HEIGHT, getGridOffsetX, getCanvasWidth } from '../config';
+import { ResponsiveManager } from './ResponsiveManager';
 import { EventBus } from './EventBus';
 
 export class UIOverlay {
@@ -16,36 +17,51 @@ export class UIOverlay {
 
   constructor(scene: Phaser.Scene, _events: EventBus, livesMode: 'lives' | 'base_hp' = 'lives') {
     this.livesMode = livesMode;
-    const uiStyle = { fontSize: '16px', color: '#ffffff', fontFamily: 'monospace' };
+    const isPhone = ResponsiveManager.isPhone();
+    const fs = isPhone ? '13px' : '16px';
+    const uiStyle = { fontSize: fs, color: '#ffffff', fontFamily: 'monospace' };
     const baseX = getGridOffsetX();
-    this.goldText = scene.add.text(baseX + 8, GAME_HEIGHT + 4, '', uiStyle).setDepth(30);
-    this.livesText = scene.add.text(baseX + 160, GAME_HEIGHT + 4, '', uiStyle).setDepth(30);
-    this.waveText = scene.add.text(baseX + 300, GAME_HEIGHT + 4, '', uiStyle).setDepth(30);
-    this.statusText = scene.add.text(baseX + 480, GAME_HEIGHT + 4, '', uiStyle).setDepth(30);
-    this.speedText = scene.add.text(getCanvasWidth() - 8, GAME_HEIGHT + 4, '', {
-      ...uiStyle, fontSize: '16px', color: '#aaaaaa',
-    }).setDepth(30).setOrigin(1, 0);
+    const cw = getCanvasWidth();
 
-    // Tappable wave start button
-    this.waveBtn = scene.add.text(baseX + 480, GAME_HEIGHT + 4, '', {
-      fontSize: '16px', color: '#44ff44', fontFamily: 'monospace',
+    // Compact layout for phone: tighter spacing
+    const col1 = baseX + 8;
+    const col2 = isPhone ? baseX + 100 : baseX + 160;
+    const col3 = isPhone ? baseX + 210 : baseX + 300;
+    const col4 = isPhone ? baseX + 320 : baseX + 480;
+
+    this.goldText = scene.add.text(col1, GAME_HEIGHT + 4, '', uiStyle).setDepth(30);
+    this.livesText = scene.add.text(col2, GAME_HEIGHT + 4, '', uiStyle).setDepth(30);
+    this.waveText = scene.add.text(col3, GAME_HEIGHT + 4, '', uiStyle).setDepth(30);
+    this.statusText = scene.add.text(col4, GAME_HEIGHT + 4, '', uiStyle).setDepth(30);
+    // On phone, hide status text (wave/speed handled by control bar)
+    if (isPhone) this.statusText.setVisible(false);
+
+    this.speedText = scene.add.text(cw - 8, GAME_HEIGHT + 4, '', {
+      ...uiStyle, color: '#aaaaaa',
+    }).setDepth(30).setOrigin(1, 0);
+    if (isPhone) this.speedText.setVisible(false);
+
+    // Tappable wave start button (hidden on phone — control bar handles it)
+    this.waveBtn = scene.add.text(col4, GAME_HEIGHT + 4, '', {
+      fontSize: fs, color: '#44ff44', fontFamily: 'monospace',
       backgroundColor: '#1a2a1a', padding: { x: 6, y: 1 },
     }).setDepth(31).setInteractive({ useHandCursor: true }).setVisible(false);
     this.waveBtn.on('pointerdown', () => this.onWaveStart?.());
     this.waveBtn.on('pointerover', () => this.waveBtn.setColor('#88ff88'));
     this.waveBtn.on('pointerout', () => this.waveBtn.setColor('#44ff44'));
 
-    // Tappable speed button
-    this.speedBtn = scene.add.text(getCanvasWidth() - 8, GAME_HEIGHT + 4, '', {
-      fontSize: '16px', color: '#aaaaaa', fontFamily: 'monospace',
+    // Tappable speed button (hidden on phone)
+    this.speedBtn = scene.add.text(cw - 8, GAME_HEIGHT + 4, '', {
+      fontSize: fs, color: '#aaaaaa', fontFamily: 'monospace',
       backgroundColor: '#1a1a2a', padding: { x: 6, y: 1 },
     }).setDepth(31).setOrigin(1, 0).setInteractive({ useHandCursor: true });
     this.speedBtn.on('pointerdown', () => this.onSpeedCycle?.());
     this.speedBtn.on('pointerover', () => this.speedBtn.setAlpha(0.7));
     this.speedBtn.on('pointerout', () => this.speedBtn.setAlpha(1));
+    if (isPhone) this.speedBtn.setVisible(false);
 
     // Seed display (shown for random maps)
-    this.seedText = scene.add.text(getCanvasWidth() - 8, 4, '', {
+    this.seedText = scene.add.text(cw - 8, 4, '', {
       fontSize: '10px', color: '#666666', fontFamily: 'monospace',
     }).setDepth(30).setOrigin(1, 0).setVisible(false);
   }
@@ -66,9 +82,11 @@ export class UIOverlay {
       } else {
         this.statusText.setText('[SPACE] Start Next Wave');
       }
-      // Show tappable wave button
-      this.waveBtn.setText(versusTimer >= 0 ? `Ready (${versusTimer}s)` : 'Start Wave');
-      this.waveBtn.setVisible(true);
+      // Show tappable wave button (not on phone — control bar handles it)
+      if (!ResponsiveManager.isPhone()) {
+        this.waveBtn.setText(versusTimer >= 0 ? `Ready (${versusTimer}s)` : 'Start Wave');
+        this.waveBtn.setVisible(true);
+      }
     } else if (waveActive) {
       this.statusText.setText('Wave in progress...');
       this.waveBtn.setVisible(false);

--- a/src/ui/GameControlBar.ts
+++ b/src/ui/GameControlBar.ts
@@ -1,0 +1,194 @@
+import { getCanvasWidth, getGameWidth, getGridOffsetX } from '../config';
+import { ArenaManager } from '../systems/ArenaManager';
+import { Hero } from '../entities/Hero';
+
+interface ControlButton {
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+  label: string;
+  color: number;
+  action: () => void;
+  // Dynamic state
+  cooldown?: () => number;  // returns seconds remaining
+  locked?: () => boolean;
+  zone: Phaser.GameObjects.Zone;
+}
+
+/**
+ * Touch control bar for phone mode.
+ * Shows wave start, speed, pause buttons (all modes)
+ * + ability buttons Q/W/E/R/T (hero defense mode).
+ */
+export class GameControlBar {
+  private scene: Phaser.Scene;
+  private graphics: Phaser.GameObjects.Graphics;
+  private buttons: ControlButton[] = [];
+  private labels: Phaser.GameObjects.Text[] = [];
+  private arenaManager: ArenaManager | null;
+
+  static readonly BAR_HEIGHT = 48;
+  private static readonly BTN_SIZE = 44;
+  private static readonly BTN_GAP = 4;
+
+  private onWaveStart: (() => void) | null = null;
+  private onSpeedCycle: (() => void) | null = null;
+  private onPause: (() => void) | null = null;
+
+  // State for display
+  private waveActive = false;
+  private betweenWaves = false;
+  private canStart = false;
+  private gameSpeed = 1;
+
+  constructor(
+    scene: Phaser.Scene,
+    y: number,
+    arenaManager: ArenaManager | null,
+  ) {
+    this.scene = scene;
+    this.arenaManager = arenaManager;
+    this.graphics = scene.add.graphics().setDepth(32);
+
+    const barY = y;
+    const { BTN_SIZE, BTN_GAP } = GameControlBar;
+    let x = getGridOffsetX() + 4;
+
+    // Wave start button
+    this.addButton(x, barY + 2, BTN_SIZE + 16, BTN_SIZE, '▶ Wave', 0x226622, () => {
+      this.onWaveStart?.();
+    });
+    x += BTN_SIZE + 16 + BTN_GAP;
+
+    // Speed button
+    this.addButton(x, barY + 2, BTN_SIZE, BTN_SIZE, '1x', 0x222244, () => {
+      this.onSpeedCycle?.();
+    });
+    x += BTN_SIZE + BTN_GAP;
+
+    // Pause button
+    this.addButton(x, barY + 2, BTN_SIZE, BTN_SIZE, '⏸', 0x333333, () => {
+      this.onPause?.();
+    });
+    x += BTN_SIZE + BTN_GAP;
+
+    // Hero defense ability buttons
+    if (arenaManager) {
+      x += 8; // gap before abilities
+
+      const hero = arenaManager.hero;
+      const abilityKeys = ['Q', 'W', 'E'];
+      for (let i = 0; i < abilityKeys.length; i++) {
+        const idx = i;
+        const ab = hero.abilities[idx];
+        this.addButton(x, barY + 2, BTN_SIZE, BTN_SIZE, abilityKeys[i], hero.typeDef.color, () => {
+          arenaManager.handleAbilityKey(idx);
+        }, () => ab.cooldownRemaining, () => false);
+        x += BTN_SIZE + BTN_GAP;
+      }
+
+      // Ultimate (R)
+      if (hero.ultimate) {
+        const ult = hero.ultimate;
+        this.addButton(x, barY + 2, BTN_SIZE, BTN_SIZE, 'R', 0x6633aa, () => {
+          arenaManager.handleAbilityKey(3);
+        }, () => ult.cooldownRemaining, () => hero.level < Hero.ULTIMATE_UNLOCK_LEVEL);
+        x += BTN_SIZE + BTN_GAP;
+      }
+
+      // Accessory (T)
+      this.addButton(x, barY + 2, BTN_SIZE, BTN_SIZE, 'T', 0x553366, () => {
+        arenaManager.handleAccessoryKey();
+      });
+    }
+  }
+
+  private addButton(
+    x: number, y: number, w: number, h: number,
+    label: string, color: number, action: () => void,
+    cooldown?: () => number, locked?: () => boolean,
+  ): void {
+    const zone = this.scene.add.zone(x + w / 2, y + h / 2, w, h)
+      .setDepth(33)
+      .setInteractive({ useHandCursor: true });
+    zone.on('pointerdown', action);
+
+    const textObj = this.scene.add.text(x + w / 2, y + h / 2, label, {
+      fontSize: '14px', color: '#ffffff', fontFamily: 'monospace',
+    }).setOrigin(0.5).setDepth(34);
+    this.labels.push(textObj);
+
+    this.buttons.push({ x, y, w, h, label, color, action, cooldown, locked, zone });
+  }
+
+  setCallbacks(onWaveStart: () => void, onSpeedCycle: () => void, onPause: () => void): void {
+    this.onWaveStart = onWaveStart;
+    this.onSpeedCycle = onSpeedCycle;
+    this.onPause = onPause;
+  }
+
+  setState(waveActive: boolean, betweenWaves: boolean, canStart: boolean, gameSpeed: number): void {
+    this.waveActive = waveActive;
+    this.betweenWaves = betweenWaves;
+    this.canStart = canStart;
+    this.gameSpeed = gameSpeed;
+  }
+
+  update(): void {
+    this.graphics.clear();
+
+    // Bar background
+    const barY = this.buttons[0]?.y ?? 0;
+    this.graphics.fillStyle(0x111118, 1);
+    this.graphics.fillRect(getGridOffsetX(), barY - 2, getCanvasWidth() - getGridOffsetX(), GameControlBar.BAR_HEIGHT);
+    this.graphics.lineStyle(1, 0x333333, 1);
+    this.graphics.lineBetween(getGridOffsetX(), barY - 2, getCanvasWidth(), barY - 2);
+
+    for (let i = 0; i < this.buttons.length; i++) {
+      const btn = this.buttons[i];
+      const label = this.labels[i];
+
+      const isLocked = btn.locked?.() ?? false;
+      const cd = btn.cooldown?.() ?? 0;
+      const onCooldown = cd > 0;
+
+      // Button background
+      const alpha = isLocked ? 0.3 : onCooldown ? 0.5 : 1;
+      this.graphics.fillStyle(btn.color, alpha);
+      this.graphics.fillRect(btn.x, btn.y, btn.w, btn.h);
+      this.graphics.lineStyle(1, 0x555555, 0.5);
+      this.graphics.strokeRect(btn.x, btn.y, btn.w, btn.h);
+
+      // Cooldown overlay
+      if (onCooldown && !isLocked) {
+        label.setText(`${Math.ceil(cd)}`);
+        label.setColor('#ff4444');
+      } else if (isLocked) {
+        label.setText(btn.label);
+        label.setColor('#555555');
+      } else {
+        // Update special labels
+        if (i === 0) {
+          // Wave button
+          label.setText(this.betweenWaves && this.canStart ? '▶' : '...');
+          label.setColor(this.betweenWaves && this.canStart ? '#44ff44' : '#555555');
+        } else if (i === 1) {
+          // Speed button
+          const speedLabel = this.gameSpeed === 0 ? '⏸' : `${this.gameSpeed}x`;
+          label.setText(speedLabel);
+          label.setColor(this.gameSpeed > 1 ? '#ffdd44' : '#aaaaaa');
+        } else {
+          label.setText(btn.label);
+          label.setColor('#ffffff');
+        }
+      }
+    }
+  }
+
+  destroy(): void {
+    this.graphics.destroy();
+    for (const btn of this.buttons) btn.zone.destroy();
+    for (const lbl of this.labels) lbl.destroy();
+  }
+}

--- a/src/ui/SidebarOverlay.ts
+++ b/src/ui/SidebarOverlay.ts
@@ -3,9 +3,10 @@ import { ResponsiveManager } from '../systems/ResponsiveManager';
 import { TowerSelectBar } from './TowerSelectBar';
 
 /**
- * Collapsible sidebar overlay for tablet mode.
- * On tablet, sidebar panels slide in/out from the left edge.
- * On desktop, this is not created — panels remain inline.
+ * Collapsible sidebar overlay for tablet/phone mode.
+ * On tablet: slides in from the left (360px wide).
+ * On phone: full-screen overlay for maximum readability.
+ * On desktop: not created — panels remain inline.
  */
 export class SidebarOverlay {
   private scene: Phaser.Scene;
@@ -15,14 +16,18 @@ export class SidebarOverlay {
   private _visible = false;
 
   private readonly totalH: number;
+  private readonly isPhone: boolean;
+  private readonly panelW: number;
 
   constructor(scene: Phaser.Scene) {
     this.scene = scene;
+    this.isPhone = ResponsiveManager.isPhone();
     this.totalH = GAME_HEIGHT + 28 + TowerSelectBar.BAR_HEIGHT;
+    this.panelW = this.isPhone ? ResponsiveManager.canvasWidth() : SIDEBAR_WIDTH;
 
     // Semi-transparent scrim behind sidebar — covers game area
     this.scrim = scene.add.graphics().setDepth(39).setVisible(false);
-    this.scrim.fillStyle(0x000000, 0.4);
+    this.scrim.fillStyle(0x000000, this.isPhone ? 0.7 : 0.4);
     this.scrim.fillRect(0, 0, scene.scale.width, this.totalH);
     this.scrim.setInteractive(
       new Phaser.Geom.Rectangle(0, 0, scene.scale.width, this.totalH),
@@ -30,22 +35,38 @@ export class SidebarOverlay {
     );
     this.scrim.on('pointerdown', () => this.hide());
 
-    // Sidebar container — starts off-screen to the left
-    this.container = scene.add.container(-SIDEBAR_WIDTH, 0).setDepth(40);
+    // Sidebar container — starts off-screen
+    this.container = scene.add.container(-this.panelW, 0).setDepth(40);
 
     // Background
     const bg = scene.add.graphics();
     bg.fillStyle(0x0e0e12, 1);
-    bg.fillRect(0, 0, SIDEBAR_WIDTH, this.totalH);
-    bg.lineStyle(1, 0x333333, 1);
-    bg.lineBetween(SIDEBAR_WIDTH, 0, SIDEBAR_WIDTH, this.totalH);
+    bg.fillRect(0, 0, this.panelW, this.totalH);
+    if (!this.isPhone) {
+      bg.lineStyle(1, 0x333333, 1);
+      bg.lineBetween(this.panelW, 0, this.panelW, this.totalH);
+    }
     this.container.add(bg);
 
+    // Close button (phone: larger, top-right)
+    if (this.isPhone) {
+      const closeBtn = scene.add.text(this.panelW - 48, 8, '✕', {
+        fontSize: '24px', color: '#aaaaaa', fontFamily: 'monospace',
+        backgroundColor: '#2a1a1a',
+        padding: { x: 8, y: 4 },
+      }).setInteractive({ useHandCursor: true });
+      closeBtn.on('pointerdown', () => this.hide());
+      closeBtn.on('pointerover', () => closeBtn.setColor('#ffffff'));
+      closeBtn.on('pointerout', () => closeBtn.setColor('#aaaaaa'));
+      this.container.add(closeBtn);
+    }
+
     // Toggle button — always visible on game area
+    const btnSize = this.isPhone ? '26px' : '22px';
     this.toggleBtn = scene.add.text(8, 8, '\u2630', {
-      fontSize: '22px', color: '#aaaaaa', fontFamily: 'monospace',
+      fontSize: btnSize, color: '#aaaaaa', fontFamily: 'monospace',
       backgroundColor: '#1a1a1a',
-      padding: { x: 6, y: 2 },
+      padding: { x: this.isPhone ? 8 : 6, y: this.isPhone ? 4 : 2 },
     }).setDepth(41).setInteractive({ useHandCursor: true });
     this.toggleBtn.on('pointerdown', () => this.toggle());
     this.toggleBtn.on('pointerover', () => this.toggleBtn.setColor('#ffffff'));
@@ -75,7 +96,7 @@ export class SidebarOverlay {
     this.scrim.setVisible(false);
     this.scene.tweens.add({
       targets: this.container,
-      x: -SIDEBAR_WIDTH,
+      x: -this.panelW,
       duration: 200,
       ease: 'Power2',
     });

--- a/src/ui/TowerSelectBar.ts
+++ b/src/ui/TowerSelectBar.ts
@@ -1,6 +1,7 @@
 import { GAME_HEIGHT, TILE_SIZE, getGridOffsetX, getCanvasWidth } from '../config';
 import { getTowerType, TowerType } from '../data/TowerTypes';
 import { hasTrait } from '../systems/traits/Trait';
+import { ResponsiveManager } from '../systems/ResponsiveManager';
 
 export class TowerSelectBar {
   private scene: Phaser.Scene;
@@ -14,13 +15,15 @@ export class TowerSelectBar {
   private tooltipText: Phaser.GameObjects.Text;
 
   static readonly BAR_HEIGHT = 68;
-  private static readonly BTN_SIZE = 52;
-  private static readonly PADDING = 10;
+  private readonly btnSize: number;
+  private readonly padding: number;
 
   constructor(scene: Phaser.Scene, towerIds: string[], onSelect: (typeId: string | null) => void) {
     this.scene = scene;
     this.towerIds = towerIds;
     this.onSelect = onSelect;
+    this.btnSize = ResponsiveManager.isPhone() ? 42 : 52;
+    this.padding = ResponsiveManager.isPhone() ? 4 : 10;
     this.container = scene.add.container(0, GAME_HEIGHT + 28).setDepth(30);
 
     // Tooltip (rendered above the bar)
@@ -46,12 +49,16 @@ export class TowerSelectBar {
     bg.lineBetween(offsetX, 0, canvasW, 0);
     this.container.add(bg);
 
-    const { BTN_SIZE, PADDING } = TowerSelectBar;
-    const startX = offsetX + PADDING;
+    const bs = this.btnSize;
+    const pad = this.padding;
+    const startX = offsetX + pad;
+    const isPhone = ResponsiveManager.isPhone();
+    const fontSize = isPhone ? '10px' : '12px';
+    const costSize = isPhone ? '9px' : '11px';
 
     for (let i = 0; i < this.towerIds.length; i++) {
       const t = getTowerType(this.towerIds[i]);
-      const x = startX + i * (BTN_SIZE + PADDING);
+      const x = startX + i * (bs + pad);
       const y = 6;
 
       const btn = this.scene.add.graphics();
@@ -59,26 +66,28 @@ export class TowerSelectBar {
       this.buttons.push(btn);
 
       const idx = i;
-      const zone = this.scene.add.zone(x + BTN_SIZE / 2, y + BTN_SIZE / 2, BTN_SIZE, BTN_SIZE);
+      const zone = this.scene.add.zone(x + bs / 2, y + bs / 2, bs, bs);
       this.container.add(zone);
       zone.setInteractive({ useHandCursor: true });
       zone.on('pointerdown', () => this.highlight(idx));
       zone.on('pointerover', () => this.showTooltip(idx));
       zone.on('pointerout', () => this.hideTooltip());
 
-      const hotkeyNum = String(i + 1);
-      const label = this.scene.add.text(x + 2, y + 1, hotkeyNum, {
-        fontSize: '12px', color: '#aaaaaa', fontFamily: 'monospace'
-      });
-      this.container.add(label);
+      if (!isPhone) {
+        const hotkeyNum = String(i + 1);
+        const label = this.scene.add.text(x + 2, y + 1, hotkeyNum, {
+          fontSize, color: '#aaaaaa', fontFamily: 'monospace'
+        });
+        this.container.add(label);
+      }
 
-      const costLabel = this.scene.add.text(x + BTN_SIZE / 2, y + BTN_SIZE - 2, `${t.cost}g`, {
-        fontSize: '11px', color: '#ffdd44', fontFamily: 'monospace'
+      const costLabel = this.scene.add.text(x + bs / 2, y + bs - 2, `${t.cost}g`, {
+        fontSize: costSize, color: '#ffdd44', fontFamily: 'monospace'
       }).setOrigin(0.5, 1);
       this.container.add(costLabel);
 
-      const nameLabel = this.scene.add.text(x + BTN_SIZE / 2, y + BTN_SIZE / 2 - 2, t.name.substring(0, 5), {
-        fontSize: '12px', color: '#ffffff', fontFamily: 'monospace'
+      const nameLabel = this.scene.add.text(x + bs / 2, y + bs / 2 - 2, t.name.substring(0, isPhone ? 4 : 5), {
+        fontSize, color: '#ffffff', fontFamily: 'monospace'
       }).setOrigin(0.5, 0.5);
       this.container.add(nameLabel);
     }
@@ -102,9 +111,8 @@ export class TowerSelectBar {
     this.tooltipBg.strokeRect(0, 0, textW, textH);
 
     // Position above the button
-    const { BTN_SIZE, PADDING } = TowerSelectBar;
-    const startX = getGridOffsetX() + PADDING;
-    const btnX = startX + index * (BTN_SIZE + PADDING);
+    const startX = getGridOffsetX() + this.padding;
+    const btnX = startX + index * (this.btnSize + this.padding);
     const barY = GAME_HEIGHT + 28;
 
     let tx = btnX;
@@ -202,26 +210,26 @@ export class TowerSelectBar {
   }
 
   private redraw(): void {
-    const { BTN_SIZE, PADDING } = TowerSelectBar;
-    const startX = getGridOffsetX() + PADDING;
+    const bs = this.btnSize;
+    const startX = getGridOffsetX() + this.padding;
 
     for (let i = 0; i < this.buttons.length; i++) {
       const t = getTowerType(this.towerIds[i]);
-      const x = startX + i * (BTN_SIZE + PADDING);
+      const x = startX + i * (bs + this.padding);
       const y = 6;
 
       const btn = this.buttons[i];
       btn.clear();
       if (i === this.selectedIndex) {
         btn.fillStyle(t.color, 0.9);
-        btn.fillRect(x, y, BTN_SIZE, BTN_SIZE);
+        btn.fillRect(x, y, bs, bs);
         btn.lineStyle(2, 0xffffff, 1);
-        btn.strokeRect(x, y, BTN_SIZE, BTN_SIZE);
+        btn.strokeRect(x, y, bs, bs);
       } else {
         btn.fillStyle(t.color, 0.4);
-        btn.fillRect(x, y, BTN_SIZE, BTN_SIZE);
+        btn.fillRect(x, y, bs, bs);
         btn.lineStyle(1, 0x555555, 0.6);
-        btn.strokeRect(x, y, BTN_SIZE, BTN_SIZE);
+        btn.strokeRect(x, y, bs, bs);
       }
     }
   }


### PR DESCRIPTION
New phone layout mode (<600px viewport) with comprehensive UI changes:

Foundation:
- Phone breakpoint in ResponsiveManager (desktop/tablet/phone)
- Dynamic grid: 20 cols on phone (560px canvas) vs 36 cols desktop (1008px)
- LayoutConfig: phone hero defense = 8 rows + 200px arena (vs 12 + 400)
- Grid, Pathfinding, InputManager all use dynamic grid.cols

Touch Controls:
- New GameControlBar: wave start, speed cycle, pause buttons + hero ability buttons (Q/W/E/R/T) with cooldown overlays
- Replaces keyboard controls — shown only on phone mode

UI Scaling:
- SidebarOverlay: full-screen on phone (not side panel), larger close button
- TowerSelectBar: 42px buttons (vs 52), tighter padding, no hotkey numbers
- UIOverlay: compact column spacing, 13px font, hidden wave/speed buttons
- ItemShopPanel inherits sidebar width automatically

Scene Layouts:
- HeroSelectScene: single-card carousel with prev/next + dots on phone
- MenuScene: multi-row map buttons, 2-col mode cards, dynamic Y offsets
- FactionSelectScene: 3-col layout, 90px cards, no tower list on phone
- All scenes use getCanvasWidth() for centering (already dynamic)