### PR TITLE
Fix mobile: wave button, tower placement, screen utilization

### DIFF
--- a/src/scenes/GameScene.ts
+++ b/src/scenes/GameScene.ts
@@ -196,9 +196,21 @@ export class GameScene extends Phaser.Scene {
     return shuffled.slice(0, 6);
   }
 
+  /** Actual game height based on layout (phone uses reduced rows) */
+  private getActualGameHeight(): number {
+    return this.layout.totalHeight;
+  }
+
   create(): void {
     // Set global grid Y offset for hero defense (arena above grid)
     setGridOffsetY(this.gridOffsetY);
+
+    // On phone, resize canvas to fit actual content (not full 26-row GAME_HEIGHT)
+    if (ResponsiveManager.isPhone()) {
+      const controlH = this.arenaManager ? GameControlBar.BAR_HEIGHT : GameControlBar.BAR_HEIGHT;
+      const totalH = this.layout.totalHeight + 28 + controlH + TowerSelectBar.BAR_HEIGHT;
+      this.scale.resize(ResponsiveManager.canvasWidth(), totalH);
+    }
 
     this._towers = [];
     this._creeps = [];
@@ -280,7 +292,8 @@ export class GameScene extends Phaser.Scene {
     if (this.layout.gridRows !== GRID_ROWS) {
       this.inputMgr.setGridRows(this.layout.gridRows);
     }
-    this.ui = new UIOverlay(this, this.eventBus, this.gridOffsetY > 0 ? 'base_hp' : 'lives');
+    const statusBarY = ResponsiveManager.isPhone() ? this.layout.totalHeight : GAME_HEIGHT;
+    this.ui = new UIOverlay(this, this.eventBus, this.gridOffsetY > 0 ? 'base_hp' : 'lives', statusBarY);
     this.ui.setCallbacks(
       () => {
         // Wave start (same as SPACE)
@@ -309,15 +322,16 @@ export class GameScene extends Phaser.Scene {
     }
 
     // Tower bar (starts deselected)
+    const towerBarY = ResponsiveManager.isPhone()
+      ? this.layout.totalHeight + 28 + GameControlBar.BAR_HEIGHT
+      : GAME_HEIGHT + 28;
     this.towerBar = new TowerSelectBar(this, this.activeTowerIds, (typeId) => {
       if (typeId) {
         this.enterBuildMode(typeId);
       } else if (this.selectionMode === 'build') {
-        // Only enter none mode if we were in build mode.
-        // If deselect was triggered by enterInspectMode, don't override it.
         this.enterNoneMode();
       }
-    });
+    }, towerBarY);
     this.towerInfo = new TowerInfoPanel(this);
     this.towerInfo.setCallbacks(
       (tower) => {
@@ -513,7 +527,7 @@ export class GameScene extends Phaser.Scene {
 
     // Phone: touch control bar with wave/speed/pause + ability buttons
     if (ResponsiveManager.isPhone()) {
-      const controlBarY = this.layout.totalHeight + 28; // below status bar
+      const controlBarY = statusBarY + 28; // below status bar
       this.controlBar = new GameControlBar(this, controlBarY, this.arenaManager);
       this.controlBar.setCallbacks(
         () => {

--- a/src/systems/InputManager.ts
+++ b/src/systems/InputManager.ts
@@ -47,7 +47,9 @@ export class InputManager {
     });
 
     scene.input.on('pointerdown', (pointer: Phaser.Input.Pointer) => {
-      if (pointer.leftButtonDown() && this.rawClickCallback) {
+      const isLeftOrTouch = pointer.leftButtonDown() || pointer.wasTouch;
+
+      if (isLeftOrTouch && this.rawClickCallback) {
         this.rawClickCallback(pointer.x, pointer.y);
       }
 
@@ -57,7 +59,11 @@ export class InputManager {
       }
 
       const coord = this.pointerToGrid(pointer);
-      if (pointer.leftButtonDown()) {
+      // On touch, trigger hover on tap so build preview shows
+      if (pointer.wasTouch && coord && this.hoverCallback) {
+        this.hoverCallback(coord.col, coord.row);
+      }
+      if (isLeftOrTouch) {
         if (coord && this.clickCallback) {
           this.clickCallback(coord.col, coord.row);
         } else if (!coord && this.clickMissCallback) {

--- a/src/systems/UIOverlay.ts
+++ b/src/systems/UIOverlay.ts
@@ -15,13 +15,14 @@ export class UIOverlay {
   private onWaveStart: (() => void) | null = null;
   private onSpeedCycle: (() => void) | null = null;
 
-  constructor(scene: Phaser.Scene, _events: EventBus, livesMode: 'lives' | 'base_hp' = 'lives') {
+  constructor(scene: Phaser.Scene, _events: EventBus, livesMode: 'lives' | 'base_hp' = 'lives', statusBarY?: number) {
     this.livesMode = livesMode;
     const isPhone = ResponsiveManager.isPhone();
     const fs = isPhone ? '13px' : '16px';
     const uiStyle = { fontSize: fs, color: '#ffffff', fontFamily: 'monospace' };
     const baseX = getGridOffsetX();
     const cw = getCanvasWidth();
+    const barY = (statusBarY ?? GAME_HEIGHT) + 4;
 
     // Compact layout for phone: tighter spacing
     const col1 = baseX + 8;
@@ -29,20 +30,20 @@ export class UIOverlay {
     const col3 = isPhone ? baseX + 210 : baseX + 300;
     const col4 = isPhone ? baseX + 320 : baseX + 480;
 
-    this.goldText = scene.add.text(col1, GAME_HEIGHT + 4, '', uiStyle).setDepth(30);
-    this.livesText = scene.add.text(col2, GAME_HEIGHT + 4, '', uiStyle).setDepth(30);
-    this.waveText = scene.add.text(col3, GAME_HEIGHT + 4, '', uiStyle).setDepth(30);
-    this.statusText = scene.add.text(col4, GAME_HEIGHT + 4, '', uiStyle).setDepth(30);
+    this.goldText = scene.add.text(col1, barY, '', uiStyle).setDepth(30);
+    this.livesText = scene.add.text(col2, barY, '', uiStyle).setDepth(30);
+    this.waveText = scene.add.text(col3, barY, '', uiStyle).setDepth(30);
+    this.statusText = scene.add.text(col4, barY, '', uiStyle).setDepth(30);
     // On phone, hide status text (wave/speed handled by control bar)
     if (isPhone) this.statusText.setVisible(false);
 
-    this.speedText = scene.add.text(cw - 8, GAME_HEIGHT + 4, '', {
+    this.speedText = scene.add.text(cw - 8, barY, '', {
       ...uiStyle, color: '#aaaaaa',
     }).setDepth(30).setOrigin(1, 0);
     if (isPhone) this.speedText.setVisible(false);
 
     // Tappable wave start button (hidden on phone — control bar handles it)
-    this.waveBtn = scene.add.text(col4, GAME_HEIGHT + 4, '', {
+    this.waveBtn = scene.add.text(col4, barY, '', {
       fontSize: fs, color: '#44ff44', fontFamily: 'monospace',
       backgroundColor: '#1a2a1a', padding: { x: 6, y: 1 },
     }).setDepth(31).setInteractive({ useHandCursor: true }).setVisible(false);
@@ -51,7 +52,7 @@ export class UIOverlay {
     this.waveBtn.on('pointerout', () => this.waveBtn.setColor('#44ff44'));
 
     // Tappable speed button (hidden on phone)
-    this.speedBtn = scene.add.text(cw - 8, GAME_HEIGHT + 4, '', {
+    this.speedBtn = scene.add.text(cw - 8, barY, '', {
       fontSize: fs, color: '#aaaaaa', fontFamily: 'monospace',
       backgroundColor: '#1a1a2a', padding: { x: 6, y: 1 },
     }).setDepth(31).setOrigin(1, 0).setInteractive({ useHandCursor: true });

--- a/src/ui/TowerSelectBar.ts
+++ b/src/ui/TowerSelectBar.ts
@@ -18,13 +18,13 @@ export class TowerSelectBar {
   private readonly btnSize: number;
   private readonly padding: number;
 
-  constructor(scene: Phaser.Scene, towerIds: string[], onSelect: (typeId: string | null) => void) {
+  constructor(scene: Phaser.Scene, towerIds: string[], onSelect: (typeId: string | null) => void, barY?: number) {
     this.scene = scene;
     this.towerIds = towerIds;
     this.onSelect = onSelect;
     this.btnSize = ResponsiveManager.isPhone() ? 42 : 52;
     this.padding = ResponsiveManager.isPhone() ? 4 : 10;
-    this.container = scene.add.container(0, GAME_HEIGHT + 28).setDepth(30);
+    this.container = scene.add.container(0, barY ?? (GAME_HEIGHT + 28)).setDepth(30);
 
     // Tooltip (rendered above the bar)
     this.tooltip = scene.add.container(0, 0).setDepth(35).setVisible(false);


### PR DESCRIPTION
Fix 1 — Wave start button not working:
- Canvas height on phone was still using full GAME_HEIGHT (26 rows), leaving control bar and tower bar off-screen. Now GameScene resizes canvas to fit actual layout height on phone.
- Status bar, control bar, and tower bar all use layout-relative Y positions instead of hardcoded GAME_HEIGHT.

Fix 2 — Tower placement not working on touch:
- Added wasTouch fallback for pointer detection (touch doesn't always set leftButtonDown in all browsers).
- Trigger hover callback on pointerdown for touch so build preview shows immediately on tap.

Fix 3 — Better screen utilization:
- Phone canvas tightly wraps: layout height + status bar + control bar + tower bar, no wasted space.
- UIOverlay accepts custom statusBarY parameter.
- TowerSelectBar accepts custom barY parameter.
- Grid is edge-to-edge at 20 cols × 28px = 560px canvas width.