### PR TITLE
Polish mobile UX: UI camera, camera gestures, scene adaption

### DIFF
--- a/src/scenes/ChangelogScene.ts
+++ b/src/scenes/ChangelogScene.ts
@@ -256,6 +256,9 @@ const CHANGELOG_ENTRIES = [
 export class ChangelogScene extends Phaser.Scene {
   private scrollY: number = 0;
   private contentHeight: number = 0;
+  private isDragging: boolean = false;
+  private dragStartY: number = 0;
+  private dragStartScrollY: number = 0;
 
   constructor() {
     super('ChangelogScene');
@@ -321,5 +324,23 @@ export class ChangelogScene extends Phaser.Scene {
       );
       container.setY(contentY + this.scrollY);
     });
+
+    // Touch drag scrolling
+    this.input.on('pointerdown', (pointer: Phaser.Input.Pointer) => {
+      this.isDragging = true;
+      this.dragStartY = pointer.y;
+      this.dragStartScrollY = this.scrollY;
+    });
+    this.input.on('pointermove', (pointer: Phaser.Input.Pointer) => {
+      if (!this.isDragging) return;
+      const dy = pointer.y - this.dragStartY;
+      this.scrollY = Phaser.Math.Clamp(
+        this.dragStartScrollY + dy,
+        -(this.contentHeight - contentH + 20),
+        0,
+      );
+      container.setY(contentY + this.scrollY);
+    });
+    this.input.on('pointerup', () => { this.isDragging = false; });
   }
 }

--- a/src/scenes/DraftScene.ts
+++ b/src/scenes/DraftScene.ts
@@ -7,6 +7,7 @@ import { MapId } from '../data/Maps';
 import { DifficultyLevel } from '../data/Difficulty';
 import { HeroId } from '../data/HeroTypes';
 import { TowerSelectBar } from '../ui/TowerSelectBar';
+import { ResponsiveManager } from '../systems/ResponsiveManager';
 
 export class DraftScene extends Phaser.Scene {
   private matchMode: MatchMode = 'standard';
@@ -34,21 +35,43 @@ export class DraftScene extends Phaser.Scene {
   create(): void {
     const cx = getCanvasWidth() / 2;
     const modifiers = getRandomModifiers(3);
+    const isPhone = ResponsiveManager.isPhone();
 
-    this.add.text(cx, 60, 'Choose a Modifier', {
-      fontSize: '24px', color: '#ffffff', fontFamily: 'monospace',
+    const titleSize = isPhone ? '22px' : '24px';
+    const subtitleSize = isPhone ? '12px' : '14px';
+    const cardFontSize = isPhone ? '12px' : '14px';
+
+    this.add.text(cx, isPhone ? 50 : 60, 'Choose a Modifier', {
+      fontSize: titleSize, color: '#ffffff', fontFamily: 'monospace',
     }).setOrigin(0.5);
 
-    this.add.text(cx, 100, 'Pick one to apply for this game', {
-      fontSize: '14px', color: '#888888', fontFamily: 'monospace',
+    this.add.text(cx, isPhone ? 82 : 100, 'Pick one to apply for this game', {
+      fontSize: subtitleSize, color: '#888888', fontFamily: 'monospace',
     }).setOrigin(0.5);
+
+    // Phone: 2 columns (top row 2, bottom row 1 centered); Desktop: 3 across
+    const cols = isPhone ? 2 : 3;
+    const w = isPhone ? 150 : 180;
+    const h = isPhone ? 110 : 100;
+    const gap = isPhone ? 12 : 20;
+    const startY = isPhone ? 110 : 160;
 
     for (let i = 0; i < modifiers.length; i++) {
       const mod = modifiers[i];
-      const x = cx - 200 + i * 200;
-      const y = 160;
-      const w = 180;
-      const h = 100;
+      let x: number;
+      let y: number;
+
+      if (isPhone) {
+        const row = Math.floor(i / cols);
+        const colIdx = i % cols;
+        const itemsInRow = Math.min(cols, modifiers.length - row * cols);
+        const rowWidth = itemsInRow * w + (itemsInRow - 1) * gap;
+        x = cx - rowWidth / 2 + colIdx * (w + gap) + w / 2;
+        y = startY + row * (h + gap);
+      } else {
+        x = cx - 200 + i * 200;
+        y = startY;
+      }
 
       const card = this.add.graphics();
       card.fillStyle(0x222222, 1);
@@ -57,11 +80,11 @@ export class DraftScene extends Phaser.Scene {
       card.strokeRect(x - w / 2, y, w, h);
 
       this.add.text(x, y + 15, mod.name, {
-        fontSize: '14px', color: '#ffaa44', fontFamily: 'monospace',
+        fontSize: cardFontSize, color: '#ffaa44', fontFamily: 'monospace',
       }).setOrigin(0.5);
 
-      this.add.text(x, y + 45, mod.description, {
-        fontSize: '14px', color: '#cccccc', fontFamily: 'monospace',
+      this.add.text(x, y + (isPhone ? 40 : 45), mod.description, {
+        fontSize: cardFontSize, color: '#cccccc', fontFamily: 'monospace',
         wordWrap: { width: w - 16 },
         align: 'center',
       }).setOrigin(0.5);
@@ -95,9 +118,12 @@ export class DraftScene extends Phaser.Scene {
       });
     }
 
-    // Skip option
-    this.add.text(cx, 300, '[ Skip - No modifier ]', {
-      fontSize: '14px', color: '#666666', fontFamily: 'monospace',
+    // Skip option — position after last row of cards
+    const totalRows = isPhone ? Math.ceil(modifiers.length / cols) : 1;
+    const skipY = isPhone ? startY + totalRows * (h + gap) + 10 : 300;
+
+    this.add.text(cx, skipY, '[ Skip - No modifier ]', {
+      fontSize: subtitleSize, color: '#666666', fontFamily: 'monospace',
     }).setOrigin(0.5).setInteractive({ useHandCursor: true })
       .on('pointerdown', () => {
         this.scene.start('GameScene', {

--- a/src/scenes/EncyclopediaScene.ts
+++ b/src/scenes/EncyclopediaScene.ts
@@ -22,6 +22,10 @@ export class EncyclopediaScene extends Phaser.Scene {
   private factionIndex: number = 0;
   private heroIndex: number = 0;
   private playableFactions: FactionId[] = [];
+  // Touch drag scrolling
+  private isDragging: boolean = false;
+  private dragStartY: number = 0;
+  private dragStartScrollY: number = 0;
 
   constructor() {
     super('EncyclopediaScene');
@@ -95,6 +99,25 @@ export class EncyclopediaScene extends Phaser.Scene {
       );
       this.contentContainer.setY(68 + this.scrollY);
     });
+
+    // Touch drag scrolling (for non-carousel tabs)
+    this.input.on('pointerdown', (pointer: Phaser.Input.Pointer) => {
+      if (this.activeTab === 'towers' || this.activeTab === 'factions' || this.activeTab === 'heroes') return;
+      this.isDragging = true;
+      this.dragStartY = pointer.y;
+      this.dragStartScrollY = this.scrollY;
+    });
+    this.input.on('pointermove', (pointer: Phaser.Input.Pointer) => {
+      if (!this.isDragging) return;
+      const dy = pointer.y - this.dragStartY;
+      this.scrollY = Phaser.Math.Clamp(
+        this.dragStartScrollY + dy,
+        -(this.contentHeight - contentH + 40),
+        0,
+      );
+      this.contentContainer.setY(68 + this.scrollY);
+    });
+    this.input.on('pointerup', () => { this.isDragging = false; });
   }
 
   private updateTabColors(): void {

--- a/src/scenes/FactionSelectScene.ts
+++ b/src/scenes/FactionSelectScene.ts
@@ -1,5 +1,6 @@
 import Phaser from 'phaser';
 import { getCanvasWidth, GAME_HEIGHT } from '../config';
+import { ResponsiveManager } from '../systems/ResponsiveManager';
 import { FACTION_ORDER, FACTIONS, FactionId } from '../data/Factions';
 import { TOWER_TYPES } from '../data/TowerTypes';
 import { MatchMode } from '../data/WaveDefinitions';
@@ -33,7 +34,7 @@ export class FactionSelectScene extends Phaser.Scene {
       fontSize: '28px', color: '#ffffff', fontFamily: 'monospace',
     }).setOrigin(0.5);
 
-    const isPhone = getCanvasWidth() < 600;
+    const isPhone = ResponsiveManager.isPhone();
     const cardW = isPhone ? 90 : 140;
     const cardH = isPhone ? 160 : 280;
     const gap = isPhone ? 4 : 6;

--- a/src/scenes/GameOverScene.ts
+++ b/src/scenes/GameOverScene.ts
@@ -3,6 +3,7 @@ import { getCanvasWidth, GAME_HEIGHT } from '../config';
 import { GameStats } from '../systems/StatsTracker';
 import { TOWER_TYPES } from '../data/TowerTypes';
 import { TowerSelectBar } from '../ui/TowerSelectBar';
+import { ResponsiveManager } from '../systems/ResponsiveManager';
 
 export interface GameOverData {
   won: boolean;
@@ -33,6 +34,16 @@ export class GameOverScene extends Phaser.Scene {
   create(data: GameOverData): void {
     const cx = getCanvasWidth() / 2;
     const totalH = GAME_HEIGHT + 28 + TowerSelectBar.BAR_HEIGHT;
+    const isPhone = ResponsiveManager.isPhone();
+
+    // Phone-adaptive sizes
+    const titleFontSize = isPhone ? '26px' : '32px';
+    const sectionFontSize = isPhone ? '11px' : '13px';
+    const bodyFontSize = isPhone ? '10px' : '13px';
+    const smallFontSize = isPhone ? '9px' : '11px';
+    const btnFontSize = isPhone ? '12px' : '14px';
+    const rowH = isPhone ? 12 : 14;
+    const leftMargin = isPhone ? 20 : 60;
 
     // Background
     this.add.graphics().fillStyle(0x0a0a0f, 1).fillRect(0, 0, getCanvasWidth(), totalH);
@@ -40,8 +51,8 @@ export class GameOverScene extends Phaser.Scene {
     const title = data.won ? 'VICTORY!' : 'DEFEAT';
     const titleColor = data.won ? '#44ff44' : '#ff4444';
 
-    this.add.text(cx, 25, title, {
-      fontSize: '32px', color: titleColor, fontFamily: 'monospace',
+    this.add.text(cx, isPhone ? 18 : 25, title, {
+      fontSize: titleFontSize, color: titleColor, fontFamily: 'monospace',
     }).setOrigin(0.5);
 
     // Overview
@@ -61,45 +72,52 @@ export class GameOverScene extends Phaser.Scene {
       `Score: ${score}${score >= highScore ? ' (NEW HIGH!)' : `  |  High: ${highScore}`}`,
     ];
 
-    this.add.text(cx, 65, overviewLines.join('\n'), {
-      fontSize: '13px', color: '#cccccc', fontFamily: 'monospace',
-      align: 'center', lineSpacing: 4,
+    this.add.text(cx, isPhone ? 50 : 65, overviewLines.join('\n'), {
+      fontSize: isPhone ? '11px' : '13px', color: '#cccccc', fontFamily: 'monospace',
+      align: 'center', lineSpacing: isPhone ? 2 : 4,
     }).setOrigin(0.5, 0);
 
     // Tower Performance Table
     if (data.stats && Object.keys(data.stats.towerStats).length > 0) {
-      const tableY = 155;
+      const tableY = isPhone ? 130 : 155;
       this.add.text(cx, tableY, 'TOWER PERFORMANCE', {
-        fontSize: '13px', color: '#ffaa44', fontFamily: 'monospace',
+        fontSize: sectionFontSize, color: '#ffaa44', fontFamily: 'monospace',
       }).setOrigin(0.5);
 
       // Header
-      const headerY = tableY + 20;
-      const colX = [60, 210, 310, 400, 500, 600];
+      const headerY = tableY + (isPhone ? 16 : 20);
+      const colX = isPhone
+        ? [leftMargin, 160, 260, 350, 440, 520]
+        : [60, 210, 310, 400, 500, 600];
       const headers = ['Tower', 'Total DMG', 'Avg DPS', 'Gold Earned', 'Shots', 'Built'];
-      headers.forEach((h, i) => {
+      // On phone, abbreviate headers
+      const displayHeaders = isPhone
+        ? ['Tower', 'DMG', 'DPS', 'Gold', 'Shots', 'Built']
+        : headers;
+      displayHeaders.forEach((h, i) => {
         this.add.text(colX[i], headerY, h, {
-          fontSize: '13px', color: '#888888', fontFamily: 'monospace',
+          fontSize: bodyFontSize, color: '#888888', fontFamily: 'monospace',
         });
       });
 
       // Divider
       const divG = this.add.graphics();
       divG.lineStyle(1, 0x444444, 0.5);
-      divG.lineBetween(50, headerY + 14, getCanvasWidth() - 50, headerY + 14);
+      divG.lineBetween(leftMargin - 10, headerY + rowH, getCanvasWidth() - (isPhone ? 20 : 50), headerY + rowH);
 
       // Rows — sorted by total damage
       const entries = Object.entries(data.stats.towerStats)
         .sort(([, a], [, b]) => b.totalDamage - a.totalDamage);
 
-      let rowY = headerY + 20;
+      let rowY = headerY + rowH + 6;
       for (const [typeId, ts] of entries) {
         const towerDef = TOWER_TYPES[typeId];
         const name = towerDef?.name ?? typeId;
         const avgDps = ts.timeAlive > 0 ? Math.round(ts.totalDamage / (ts.timeAlive / 1000)) : 0;
 
+        const displayName = isPhone && name.length > 12 ? name.substring(0, 11) + '.' : name;
         const values = [
-          name,
+          displayName,
           ts.totalDamage.toLocaleString(),
           `${avgDps}/s`,
           ts.totalGoldEarned > 0 ? `+${ts.totalGoldEarned}g` : '-',
@@ -110,26 +128,26 @@ export class GameOverScene extends Phaser.Scene {
         const rowColor = ts.totalDamage > 0 ? '#cccccc' : '#666666';
         values.forEach((v, i) => {
           this.add.text(colX[i], rowY, v, {
-            fontSize: '13px', color: rowColor, fontFamily: 'monospace',
+            fontSize: bodyFontSize, color: rowColor, fontFamily: 'monospace',
           });
         });
-        rowY += 14;
+        rowY += rowH;
       }
 
       // Economy table — positioned dynamically after tower table
-      const econY = rowY + 16;
+      const econY = rowY + (isPhone ? 10 : 16);
       this.add.text(cx, econY, 'ECONOMY', {
-        fontSize: '13px', color: '#ffaa44', fontFamily: 'monospace',
+        fontSize: sectionFontSize, color: '#ffaa44', fontFamily: 'monospace',
       }).setOrigin(0.5);
 
       const s = data.stats;
       const towerBonusGold = Object.values(s.towerStats).reduce((sum, t) => sum + t.totalGoldEarned, 0);
-      const econHeaderY = econY + 18;
-      const econColX = [60, 250, 500];
+      const econHeaderY = econY + (isPhone ? 14 : 18);
+      const econColX = isPhone ? [leftMargin, 200, 400] : [60, 250, 500];
       const econHeaders = ['Stat', 'Value', 'Detail'];
       econHeaders.forEach((h, i) => {
         this.add.text(econColX[i], econHeaderY, h, {
-          fontSize: '11px', color: '#888888', fontFamily: 'monospace',
+          fontSize: smallFontSize, color: '#888888', fontFamily: 'monospace',
         });
       });
 
@@ -143,18 +161,18 @@ export class GameOverScene extends Phaser.Scene {
         ['Kill Efficiency', `${s.creepsKilled > 0 ? (s.totalGoldEarned / s.creepsKilled).toFixed(1) : 0}g/kill`, ''],
       ];
 
-      let econRowY = econHeaderY + 16;
+      let econRowY = econHeaderY + (isPhone ? 12 : 16);
       for (const row of econRows) {
         row.forEach((v, i) => {
           this.add.text(econColX[i], econRowY, v, {
-            fontSize: '11px', color: '#cccccc', fontFamily: 'monospace',
+            fontSize: smallFontSize, color: '#cccccc', fontFamily: 'monospace',
           });
         });
-        econRowY += 14;
+        econRowY += rowH;
       }
 
       // Fun stats
-      const funY = econRowY + 8;
+      const funY = econRowY + (isPhone ? 4 : 8);
       const topDamage = entries[0];
       const topGold = entries.reduce((best, e) =>
         e[1].totalGoldEarned > (best?.[1]?.totalGoldEarned ?? 0) ? e : best, entries[0]);
@@ -170,17 +188,18 @@ export class GameOverScene extends Phaser.Scene {
       }
       funLines.push(`Overall DPS: ${gameTime > 0 ? Math.round(entries.reduce((s, e) => s + e[1].totalDamage, 0) / gameTime) : 0}/s`);
 
-      this.add.text(cx, funY, funLines.join('  |  '), {
-        fontSize: '11px', color: '#88aacc', fontFamily: 'monospace',
+      this.add.text(cx, funY, isPhone ? funLines.join('\n') : funLines.join('  |  '), {
+        fontSize: smallFontSize, color: '#88aacc', fontFamily: 'monospace',
+        align: 'center',
       }).setOrigin(0.5);
     }
 
     // Hero defense stats
     if (data.heroStats) {
       const hs = data.heroStats;
-      const heroY = 490;
+      const heroY = isPhone ? 460 : 490;
       this.add.text(cx, heroY, 'HERO PERFORMANCE', {
-        fontSize: '13px', color: '#ff44aa', fontFamily: 'monospace',
+        fontSize: sectionFontSize, color: '#ff44aa', fontFamily: 'monospace',
       }).setOrigin(0.5);
 
       const heroLines = [
@@ -188,23 +207,23 @@ export class GameOverScene extends Phaser.Scene {
         `Kills: ${hs.kills}  |  Deaths: ${hs.deaths}  |  K/D: ${hs.deaths > 0 ? (hs.kills / hs.deaths).toFixed(1) : hs.kills}`,
         `Damage Dealt: ${hs.damageDealt.toLocaleString()}  |  Abilities Used: ${hs.abilitiesUsed}`,
       ];
-      this.add.text(cx, heroY + 18, heroLines.join('\n'), {
-        fontSize: '11px', color: '#cccccc', fontFamily: 'monospace',
-        align: 'center', lineSpacing: 4,
+      this.add.text(cx, heroY + (isPhone ? 14 : 18), heroLines.join('\n'), {
+        fontSize: smallFontSize, color: '#cccccc', fontFamily: 'monospace',
+        align: 'center', lineSpacing: isPhone ? 2 : 4,
       }).setOrigin(0.5, 0);
     }
 
     // Versus summary
     if (data.isVersus) {
-      const vsY = 520;
+      const vsY = isPhone ? 490 : 520;
       this.add.text(cx, vsY, 'VERSUS RESULTS', {
-        fontSize: '14px', color: '#ff8844', fontFamily: 'monospace',
+        fontSize: btnFontSize, color: '#ff8844', fontFamily: 'monospace',
       }).setOrigin(0.5);
 
       const winner = data.won ? 'YOU WON!' : 'YOU LOST';
       const winColor = data.won ? '#44ff44' : '#ff4444';
-      this.add.text(cx, vsY + 22, winner, {
-        fontSize: '18px', color: winColor, fontFamily: 'monospace',
+      this.add.text(cx, vsY + (isPhone ? 18 : 22), winner, {
+        fontSize: isPhone ? '16px' : '18px', color: winColor, fontFamily: 'monospace',
       }).setOrigin(0.5);
 
       const myLives = data.lives ?? 0;
@@ -223,24 +242,25 @@ export class GameOverScene extends Phaser.Scene {
         vsLines.push(`Opponent Wave: ${os.wave}  |  Opponent Kills: ${os.stats.creepsKilled}`);
       }
 
-      this.add.text(cx, vsY + 50, vsLines.join('\n'), {
-        fontSize: '14px', color: '#cccccc', fontFamily: 'monospace',
-        align: 'center', lineSpacing: 4,
+      this.add.text(cx, vsY + (isPhone ? 40 : 50), vsLines.join('\n'), {
+        fontSize: isPhone ? '11px' : '14px', color: '#cccccc', fontFamily: 'monospace',
+        align: 'center', lineSpacing: isPhone ? 2 : 4,
       }).setOrigin(0.5, 0);
     }
 
     // Buttons
-    const btnY = totalH - 50;
+    const btnY = totalH - (isPhone ? 40 : 50);
+    const btnSpacing = isPhone ? 80 : 100;
 
-    const retryBtn = this.add.text(cx - 100, btnY, '[ Play Again ]', {
-      fontSize: '14px', color: '#ffaa44', fontFamily: 'monospace',
+    const retryBtn = this.add.text(cx - btnSpacing, btnY, '[ Play Again ]', {
+      fontSize: btnFontSize, color: '#ffaa44', fontFamily: 'monospace',
     }).setOrigin(0.5).setInteractive({ useHandCursor: true });
     retryBtn.on('pointerdown', () => this.scene.start('MenuScene'));
     retryBtn.on('pointerover', () => retryBtn.setColor('#ffffff'));
     retryBtn.on('pointerout', () => retryBtn.setColor('#ffaa44'));
 
-    const menuBtn = this.add.text(cx + 100, btnY, '[ Menu ]', {
-      fontSize: '14px', color: '#4488ff', fontFamily: 'monospace',
+    const menuBtn = this.add.text(cx + btnSpacing, btnY, '[ Menu ]', {
+      fontSize: btnFontSize, color: '#4488ff', fontFamily: 'monospace',
     }).setOrigin(0.5).setInteractive({ useHandCursor: true });
     menuBtn.on('pointerdown', () => this.scene.start('MenuScene'));
     menuBtn.on('pointerover', () => menuBtn.setColor('#ffffff'));

--- a/src/scenes/GameScene.ts
+++ b/src/scenes/GameScene.ts
@@ -682,6 +682,45 @@ export class GameScene extends Phaser.Scene {
         ? this.circle.getWaveTimerSeconds()
         : -1;
     this.ui.update(this.economy.gold, this.lives, this.currentWave, this.waves.length, this.waveActive, this.betweenWaves, this.gameSpeed, versusTimer);
+
+    // Phone: set up UI camera so HUD stays fixed while game camera zooms/pans
+    if (ResponsiveManager.isPhone()) {
+      this.setupUiCamera();
+    }
+  }
+
+  /** Create a UI camera that renders HUD elements at 1x zoom, no scroll.
+   *  Main camera ignores HUD objects; UI camera ignores game objects. */
+  private setupUiCamera(): void {
+    const canvasW = getCanvasWidth();
+    const canvasH = ResponsiveManager.canvasHeight();
+    this.uiCamera = this.cameras.add(0, 0, canvasW, canvasH);
+    this.uiCamera.setScroll(0, 0);
+    this.uiCamera.setName('ui');
+
+    // Split all existing children by depth:
+    // depth < 28 = game world (ignore from UI camera)
+    // depth >= 28 = UI (ignore from main camera)
+    const mainCam = this.cameras.main;
+    for (const child of this.children.list) {
+      const d = (child as any).depth ?? 0;
+      if (d >= 28) {
+        mainCam.ignore(child);
+      } else {
+        this.uiCamera.ignore(child);
+      }
+    }
+
+    // Auto-categorize newly added objects
+    this.events.on('addedtoscene', (go: Phaser.GameObjects.GameObject) => {
+      if (!this.uiCamera) return;
+      const d = (go as any).depth ?? 0;
+      if (d >= 28) {
+        mainCam.ignore(go);
+      } else {
+        this.uiCamera.ignore(go);
+      }
+    });
   }
 
   // === Selection Mode Management ===
@@ -1038,6 +1077,7 @@ export class GameScene extends Phaser.Scene {
 
     // Ability VFX
     if (this.abilitySystem) this.abilitySystem.update(delta);
+    if (this.cameraCtrl) this.cameraCtrl.update(delta);
 
     // Versus: wave timer, minimap, incoming sends, ping, disconnect, chat
     if (this.versus) {

--- a/src/scenes/LobbyScene.ts
+++ b/src/scenes/LobbyScene.ts
@@ -6,6 +6,7 @@ import { MapId, MAP_ORDER, MAPS } from '../data/Maps';
 import { DifficultyLevel } from '../data/Difficulty';
 import { FACTION_ORDER, FACTIONS, FactionId } from '../data/Factions';
 import { TowerSelectBar } from '../ui/TowerSelectBar';
+import { ResponsiveManager } from '../systems/ResponsiveManager';
 
 export class LobbyScene extends Phaser.Scene {
   private versus: VersusManager | null = null;
@@ -165,20 +166,25 @@ export class LobbyScene extends Phaser.Scene {
   private showGameSetup(): void {
     this.codeDisplay.setText('');
     const cx = getCanvasWidth() / 2;
+    const isPhone = ResponsiveManager.isPhone();
 
     // Host picks map + difficulty
     if (this.isHost) {
-      this.add.text(cx, 195, 'Map:', { fontSize: '13px', color: '#aaaaaa', fontFamily: 'monospace' }).setOrigin(0.5);
+      this.add.text(cx, 195, 'Map:', { fontSize: isPhone ? '11px' : '13px', color: '#aaaaaa', fontFamily: 'monospace' }).setOrigin(0.5);
 
       const mapBtns: { btn: Phaser.GameObjects.Text; id: MapId }[] = [];
-      const mapStartX = cx - (MAP_ORDER.length * 80) / 2;
+      const mapSpacing = isPhone ? 55 : 80;
+      const mapCols = isPhone ? Math.min(MAP_ORDER.length, Math.floor((getCanvasWidth() - 20) / mapSpacing)) : MAP_ORDER.length;
       for (let i = 0; i < MAP_ORDER.length; i++) {
         const mid = MAP_ORDER[i];
         const isRandom = mid === 'random';
         const activeColor = isRandom ? '#ff44ff' : '#ffffff';
         const inactiveColor = isRandom ? '#884488' : '#666666';
-        const btn = this.add.text(mapStartX + i * 80 + 40, 212, MAPS[mid].name, {
-          fontSize: '13px', color: mid === this.selectedMap ? activeColor : inactiveColor, fontFamily: 'monospace',
+        const col = i % mapCols;
+        const row = Math.floor(i / mapCols);
+        const rowStartX = cx - (Math.min(mapCols, MAP_ORDER.length - row * mapCols) * mapSpacing) / 2;
+        const btn = this.add.text(rowStartX + col * mapSpacing + mapSpacing / 2, 212 + row * 18, MAPS[mid].name, {
+          fontSize: isPhone ? '10px' : '13px', color: mid === this.selectedMap ? activeColor : inactiveColor, fontFamily: 'monospace',
         }).setOrigin(0.5).setInteractive({ useHandCursor: true });
         btn.on('pointerdown', () => {
           this.selectedMap = mid;
@@ -190,17 +196,20 @@ export class LobbyScene extends Phaser.Scene {
         mapBtns.push({ btn, id: mid });
       }
 
-      this.add.text(cx, 230, 'Difficulty:', { fontSize: '13px', color: '#aaaaaa', fontFamily: 'monospace' }).setOrigin(0.5);
+      const mapRows = Math.ceil(MAP_ORDER.length / mapCols);
+      const diffLabelY = 230 + (mapRows - 1) * 18;
+      this.add.text(cx, diffLabelY, 'Difficulty:', { fontSize: isPhone ? '11px' : '13px', color: '#aaaaaa', fontFamily: 'monospace' }).setOrigin(0.5);
 
       const diffs: DifficultyLevel[] = ['easy', 'normal', 'hard', 'insane'];
       const diffColors: Record<string, string> = { easy: '#44ff44', normal: '#ffaa44', hard: '#ff4444', insane: '#ff00ff' };
       const diffBtns: { btn: Phaser.GameObjects.Text; id: DifficultyLevel }[] = [];
-      const diffStartX = cx - (diffs.length * 80) / 2;
+      const diffSpacing = isPhone ? 60 : 80;
+      const diffStartX = cx - (diffs.length * diffSpacing) / 2;
       for (let i = 0; i < diffs.length; i++) {
         const did = diffs[i];
         const isSelected = did === this.selectedDifficulty;
-        const btn = this.add.text(diffStartX + i * 80 + 40, 248, did.charAt(0).toUpperCase() + did.slice(1), {
-          fontSize: '13px', color: isSelected ? diffColors[did] : '#444444', fontFamily: 'monospace',
+        const btn = this.add.text(diffStartX + i * diffSpacing + diffSpacing / 2, diffLabelY + 18, did.charAt(0).toUpperCase() + did.slice(1), {
+          fontSize: isPhone ? '11px' : '13px', color: isSelected ? diffColors[did] : '#444444', fontFamily: 'monospace',
         }).setOrigin(0.5).setInteractive({ useHandCursor: true });
         btn.on('pointerdown', () => {
           this.selectedDifficulty = did;
@@ -210,21 +219,21 @@ export class LobbyScene extends Phaser.Scene {
       }
     } else {
       this.add.text(cx, 215, 'Host is choosing map & difficulty...', {
-        fontSize: '14px', color: '#888888', fontFamily: 'monospace',
+        fontSize: isPhone ? '12px' : '14px', color: '#888888', fontFamily: 'monospace',
       }).setOrigin(0.5);
     }
 
     // Faction cards
     const factionY = this.isHost ? 275 : 245;
     this.add.text(cx, factionY, 'Pick your faction:', {
-      fontSize: '14px', color: '#ffffff', fontFamily: 'monospace',
+      fontSize: isPhone ? '12px' : '14px', color: '#ffffff', fontFamily: 'monospace',
     }).setOrigin(0.5);
 
     const playable = FACTION_ORDER;
-    const cardW = 120;
-    const cardH = 50;
-    const gap = 6;
-    const cols = 6;
+    const cardW = isPhone ? 80 : 120;
+    const cardH = isPhone ? 40 : 50;
+    const gap = isPhone ? 4 : 6;
+    const cols = isPhone ? 3 : 6;
 
     for (let i = 0; i < playable.length; i++) {
       const fid = playable[i];
@@ -244,13 +253,13 @@ export class LobbyScene extends Phaser.Scene {
       card.lineStyle(2, faction.primaryColor, 0.8);
       card.strokeRect(x, y, cardW, h);
 
-      this.add.text(x + cardW / 2, y + 15, faction.name, {
-        fontSize: '13px', color: '#ffffff', fontFamily: 'monospace',
+      this.add.text(x + cardW / 2, y + (isPhone ? 12 : 15), faction.name, {
+        fontSize: isPhone ? '10px' : '13px', color: '#ffffff', fontFamily: 'monospace',
       }).setOrigin(0.5);
 
       const tCount = fid === 'random' ? '6/wave' : `${faction.towerIds.length} towers`;
-      this.add.text(x + cardW / 2, y + 35, tCount, {
-        fontSize: '13px', color: '#888888', fontFamily: 'monospace',
+      this.add.text(x + cardW / 2, y + (isPhone ? 28 : 35), tCount, {
+        fontSize: isPhone ? '9px' : '13px', color: '#888888', fontFamily: 'monospace',
       }).setOrigin(0.5);
 
       const zone = this.add.zone(x + cardW / 2, y + h / 2, cardW, h).setInteractive({ useHandCursor: true });

--- a/src/systems/CameraController.ts
+++ b/src/systems/CameraController.ts
@@ -3,19 +3,30 @@ import { ResponsiveManager } from './ResponsiveManager';
 const MIN_ZOOM = 1.0;
 const MAX_ZOOM = 3.0;
 const DEFAULT_PHONE_ZOOM = 1.8;
-const PAN_THRESHOLD = 8; // pixels moved before it counts as a pan (vs tap)
+const PAN_THRESHOLD = 12;       // screen pixels moved before it counts as a pan
+const MOMENTUM_FRICTION = 0.92; // velocity multiplier per frame (< 1 = deceleration)
+const MOMENTUM_MIN = 0.5;       // stop momentum below this velocity
+const ELASTIC_FACTOR = 0.3;     // how far past bounds you can drag (0-1)
+const ELASTIC_SNAP = 0.15;      // snap-back speed per frame
+const DOUBLE_TAP_MS = 300;      // max ms between taps for double-tap
 
 /**
- * Handles pinch-to-zoom and drag-to-pan for the game camera on phone.
- * UI elements should be on a separate camera (uiCamera) that doesn't zoom.
+ * Handles pinch-to-zoom, drag-to-pan, momentum, elastic bounds,
+ * and double-tap-to-zoom for the game camera on phone.
  */
 export class CameraController {
   private scene: Phaser.Scene;
-  private camera: Phaser.Cameras.Scene2D.Camera;
+  camera: Phaser.Cameras.Scene2D.Camera;
+  private worldW: number;
+  private worldH: number;
 
   // Pinch state
   private pinchStartDist: number = 0;
   private pinchStartZoom: number = 1;
+  private pinchMidX: number = 0;
+  private pinchMidY: number = 0;
+  private pinchStartScrollX: number = 0;
+  private pinchStartScrollY: number = 0;
 
   // Pan state
   private isPanning: boolean = false;
@@ -23,7 +34,16 @@ export class CameraController {
   private panStartY: number = 0;
   private panStartScrollX: number = 0;
   private panStartScrollY: number = 0;
-  private totalMoved: number = 0;
+  private prevPointerX: number = 0;
+  private prevPointerY: number = 0;
+  private movedDist: number = 0; // total distance moved from start (not accumulated per frame)
+
+  // Momentum
+  private velocityX: number = 0;
+  private velocityY: number = 0;
+
+  // Double-tap
+  private lastTapTime: number = 0;
 
   /** True if the last pointer interaction was a pan (suppress click) */
   wasPan: boolean = false;
@@ -31,13 +51,12 @@ export class CameraController {
   constructor(scene: Phaser.Scene, worldWidth: number, worldHeight: number) {
     this.scene = scene;
     this.camera = scene.cameras.main;
+    this.worldW = worldWidth;
+    this.worldH = worldHeight;
 
-    // Set camera bounds to the game world
-    this.camera.setBounds(0, 0, worldWidth, worldHeight);
-
+    // Don't use setBounds — we handle elastic bounds manually
     if (ResponsiveManager.isPhone()) {
       this.camera.setZoom(DEFAULT_PHONE_ZOOM);
-      // Center camera on the middle of the grid
       this.camera.centerOn(worldWidth / 2, worldHeight / 2);
     }
 
@@ -50,14 +69,17 @@ export class CameraController {
     const input = this.scene.input;
 
     input.on('pointerdown', (pointer: Phaser.Input.Pointer) => {
-      // Only handle single-finger for panning (pinch handled separately)
       if (input.pointer1.isDown && input.pointer2.isDown) return;
 
       this.isPanning = true;
       this.wasPan = false;
-      this.totalMoved = 0;
+      this.movedDist = 0;
+      this.velocityX = 0;
+      this.velocityY = 0;
       this.panStartX = pointer.x;
       this.panStartY = pointer.y;
+      this.prevPointerX = pointer.x;
+      this.prevPointerY = pointer.y;
       this.panStartScrollX = this.camera.scrollX;
       this.panStartScrollY = this.camera.scrollY;
     });
@@ -68,20 +90,25 @@ export class CameraController {
         this.isPanning = false;
         const p1 = input.pointer1;
         const p2 = input.pointer2;
-        const dist = Math.sqrt(
-          (p1.x - p2.x) ** 2 + (p1.y - p2.y) ** 2,
-        );
+        const dist = Math.sqrt((p1.x - p2.x) ** 2 + (p1.y - p2.y) ** 2);
 
         if (this.pinchStartDist === 0) {
           this.pinchStartDist = dist;
           this.pinchStartZoom = this.camera.zoom;
+          // Record midpoint in world coords for centered zoom
+          this.pinchMidX = (p1.x + p2.x) / 2;
+          this.pinchMidY = (p1.y + p2.y) / 2;
+          this.pinchStartScrollX = this.camera.scrollX;
+          this.pinchStartScrollY = this.camera.scrollY;
         } else {
           const scale = dist / this.pinchStartDist;
-          const newZoom = Phaser.Math.Clamp(
-            this.pinchStartZoom * scale,
-            MIN_ZOOM, MAX_ZOOM,
-          );
+          const newZoom = Phaser.Math.Clamp(this.pinchStartZoom * scale, MIN_ZOOM, MAX_ZOOM);
+          // Zoom centered on pinch midpoint
+          const midWorldX = this.pinchMidX / this.pinchStartZoom + this.pinchStartScrollX;
+          const midWorldY = this.pinchMidY / this.pinchStartZoom + this.pinchStartScrollY;
           this.camera.setZoom(newZoom);
+          this.camera.scrollX = midWorldX - this.pinchMidX / newZoom;
+          this.camera.scrollY = midWorldY - this.pinchMidY / newZoom;
         }
         return;
       }
@@ -90,35 +117,98 @@ export class CameraController {
       if (this.isPanning && pointer.isDown) {
         const dx = pointer.x - this.panStartX;
         const dy = pointer.y - this.panStartY;
-        this.totalMoved += Math.abs(dx) + Math.abs(dy);
+        this.movedDist = Math.sqrt(dx * dx + dy * dy);
 
-        if (this.totalMoved > PAN_THRESHOLD) {
+        // Track velocity from frame-to-frame movement
+        this.velocityX = (pointer.x - this.prevPointerX) / this.camera.zoom;
+        this.velocityY = (pointer.y - this.prevPointerY) / this.camera.zoom;
+        this.prevPointerX = pointer.x;
+        this.prevPointerY = pointer.y;
+
+        if (this.movedDist > PAN_THRESHOLD) {
           this.wasPan = true;
-          // Pan inversely to zoom (moving finger 10px at 2x zoom = 5px scroll)
           this.camera.scrollX = this.panStartScrollX - dx / this.camera.zoom;
           this.camera.scrollY = this.panStartScrollY - dy / this.camera.zoom;
         }
       }
     });
 
-    input.on('pointerup', () => {
+    input.on('pointerup', (pointer: Phaser.Input.Pointer) => {
+      if (this.isPanning && !this.wasPan) {
+        // Check double-tap
+        const now = Date.now();
+        if (now - this.lastTapTime < DOUBLE_TAP_MS) {
+          this.doubleTapZoom(pointer.x, pointer.y);
+          this.lastTapTime = 0;
+        } else {
+          this.lastTapTime = now;
+        }
+      }
       this.isPanning = false;
       this.pinchStartDist = 0;
+      // Momentum continues in update()
     });
   }
 
-  /** Get current zoom level */
-  get zoom(): number {
-    return this.camera.zoom;
+  /** Double-tap: toggle between default zoom and 1x */
+  private doubleTapZoom(screenX: number, screenY: number): void {
+    const targetZoom = this.camera.zoom > 1.2 ? 1.0 : DEFAULT_PHONE_ZOOM;
+    // Zoom toward tap point
+    const worldX = screenX / this.camera.zoom + this.camera.scrollX;
+    const worldY = screenY / this.camera.zoom + this.camera.scrollY;
+    this.camera.setZoom(targetZoom);
+    this.camera.scrollX = worldX - screenX / targetZoom;
+    this.camera.scrollY = worldY - screenY / targetZoom;
+    this.velocityX = 0;
+    this.velocityY = 0;
+    this.wasPan = true; // suppress the tap click
   }
 
-  /** Convert screen coords to world coords (for input handling) */
-  screenToWorld(screenX: number, screenY: number): { x: number; y: number } {
+  /** Call each frame to apply momentum and elastic bounds */
+  update(delta: number): void {
+    if (!ResponsiveManager.isPhone()) return;
+
+    // Apply momentum when not actively panning
+    if (!this.isPanning && (Math.abs(this.velocityX) > MOMENTUM_MIN || Math.abs(this.velocityY) > MOMENTUM_MIN)) {
+      this.camera.scrollX -= this.velocityX;
+      this.camera.scrollY -= this.velocityY;
+      this.velocityX *= MOMENTUM_FRICTION;
+      this.velocityY *= MOMENTUM_FRICTION;
+    }
+
+    // Elastic bounds: calculate where camera should be clamped
     const cam = this.camera;
-    return {
-      x: screenX / cam.zoom + cam.scrollX,
-      y: screenY / cam.zoom + cam.scrollY,
-    };
+    const viewW = cam.width / cam.zoom;
+    const viewH = cam.height / cam.zoom;
+    const minX = 0;
+    const minY = 0;
+    const maxX = Math.max(0, this.worldW - viewW);
+    const maxY = Math.max(0, this.worldH - viewH);
+
+    // If actively dragging, allow elastic overscroll
+    if (this.isPanning) {
+      // Soft clamp: resist going past bounds
+      if (cam.scrollX < minX) {
+        cam.scrollX = minX - (minX - cam.scrollX) * (1 - ELASTIC_FACTOR);
+      } else if (cam.scrollX > maxX) {
+        cam.scrollX = maxX + (cam.scrollX - maxX) * ELASTIC_FACTOR;
+      }
+      if (cam.scrollY < minY) {
+        cam.scrollY = minY - (minY - cam.scrollY) * (1 - ELASTIC_FACTOR);
+      } else if (cam.scrollY > maxY) {
+        cam.scrollY = maxY + (cam.scrollY - maxY) * ELASTIC_FACTOR;
+      }
+    } else {
+      // Snap back to bounds
+      if (cam.scrollX < minX) cam.scrollX += (minX - cam.scrollX) * ELASTIC_SNAP;
+      else if (cam.scrollX > maxX) cam.scrollX -= (cam.scrollX - maxX) * ELASTIC_SNAP;
+      if (cam.scrollY < minY) cam.scrollY += (minY - cam.scrollY) * ELASTIC_SNAP;
+      else if (cam.scrollY > maxY) cam.scrollY -= (cam.scrollY - maxY) * ELASTIC_SNAP;
+    }
+  }
+
+  get zoom(): number {
+    return this.camera.zoom;
   }
 
   destroy(): void {

--- a/src/ui/CreepInfoPanel.ts
+++ b/src/ui/CreepInfoPanel.ts
@@ -13,7 +13,7 @@ export class CreepInfoPanel {
 
   constructor(scene: Phaser.Scene) {
     this.scene = scene;
-    this.container = scene.add.container(0, 0).setDepth(25).setVisible(false);
+    this.container = scene.add.container(0, 0).setDepth(29).setVisible(false);
 
     this.bg = scene.add.graphics();
     this.container.add(this.bg);
@@ -87,10 +87,14 @@ export class CreepInfoPanel {
     const panelW = 280;
     const panelH = 52 + allEffects.length * 13 + 8;
 
-    // Position near creep
-    let px = c.x + TILE_SIZE;
-    let py = c.y - panelH / 2;
-    if (px + panelW > getCanvasWidth()) px = c.x - TILE_SIZE - panelW;
+    // Position near creep — screen coords on phone
+    const cam = this.scene.cameras.main;
+    const sx = (c.x - cam.scrollX) * cam.zoom;
+    const sy = (c.y - cam.scrollY) * cam.zoom;
+    const useScreen = cam.zoom !== 1;
+    let px = (useScreen ? sx : c.x) + TILE_SIZE;
+    let py = (useScreen ? sy : c.y) - panelH / 2;
+    if (px + panelW > getCanvasWidth()) px = (useScreen ? sx : c.x) - TILE_SIZE - panelW;
     if (px < getGridOffsetX()) px = getGridOffsetX();
     if (py < 0) py = 0;
 

--- a/src/ui/ItemShopPanel.ts
+++ b/src/ui/ItemShopPanel.ts
@@ -3,6 +3,7 @@ import { Hero } from '../entities/Hero';
 import { ITEM_SLOTS, ITEM_SLOT_ORDER, ItemSlot } from '../data/HeroItems';
 import { EconomyManager } from '../systems/EconomyManager';
 import { ArenaManager } from '../systems/ArenaManager';
+import { ResponsiveManager } from '../systems/ResponsiveManager';
 import { EventLog } from './EventLog';
 
 export class ItemShopPanel {
@@ -59,11 +60,19 @@ export class ItemShopPanel {
     this.rebuildDynamic();
   }
 
+  /** Phone-aware font size: adds 2px on phone */
+  private fs(base: number): string {
+    return `${base + (ResponsiveManager.isPhone() ? 2 : 0)}px`;
+  }
+
   private rebuildDynamic(): void {
     for (const obj of this.dynamicItems) {
       this.container.remove(obj, true);
     }
     this.dynamicItems = [];
+    const ph = ResponsiveManager.isPhone();
+    const rh = ph ? 18 : 14; // row height
+    const gap = ph ? 4 : 2;  // gap between sections
 
     let y = 42;
 

--- a/src/ui/SendPanel.ts
+++ b/src/ui/SendPanel.ts
@@ -1,5 +1,6 @@
 import { SIDEBAR_WIDTH } from '../config';
 import { SEND_OPTIONS, SendCreepOption, getSendCost, getSendIncome } from '../data/SendCreepTypes';
+import { ResponsiveManager } from '../systems/ResponsiveManager';
 
 const SEND_HOTKEYS = ['Z', 'X', 'C', 'V', '1', '2', '3', '4'];
 
@@ -55,14 +56,16 @@ export class SendPanel {
     this.container.add(subtitle);
 
     this.labels = [];
+    const isPhone = ResponsiveManager.isPhone();
+    const rowH = isPhone ? 26 : 17;
+    const fontSize = isPhone ? '13px' : '10px';
     for (let i = 0; i < SEND_OPTIONS.length; i++) {
       const opt = SEND_OPTIONS[i];
       const hotkey = SEND_HOTKEYS[i] || '';
-      const y = 24 + i * 17;
+      const y = 24 + i * rowH;
 
-      // Scrollable area check — if more than 4 sends, we need tighter spacing
       const text = this.scene.add.text(8, y, '', {
-        fontSize: '10px', color: '#cccccc', fontFamily: 'monospace',
+        fontSize, color: '#cccccc', fontFamily: 'monospace',
       });
 
       this.container.add(text);

--- a/src/ui/TowerInfoPanel.ts
+++ b/src/ui/TowerInfoPanel.ts
@@ -21,7 +21,7 @@ export class TowerInfoPanel {
 
   constructor(scene: Phaser.Scene) {
     this.scene = scene;
-    this.container = scene.add.container(0, 0).setDepth(25).setVisible(false);
+    this.container = scene.add.container(0, 0).setDepth(29).setVisible(false);
 
     this.bg = scene.add.graphics();
     this.container.add(this.bg);
@@ -167,12 +167,18 @@ export class TowerInfoPanel {
     const panelW = 350;
     const panelH = btnY + 24;
 
-    // Position near tower
-    let px = tower.x + TILE_SIZE;
-    let py = tower.y - panelH / 2;
-    if (px + panelW > getCanvasWidth()) px = tower.x - TILE_SIZE - panelW;
+    // Position near tower — convert to screen coords on phone (UI camera is at 1x)
+    const cam = this.scene.cameras.main;
+    const screenTowerX = (tower.x - cam.scrollX) * cam.zoom;
+    const screenTowerY = (tower.y - cam.scrollY) * cam.zoom;
+    const useScreen = cam.zoom !== 1; // phone with zoom
+
+    let px = (useScreen ? screenTowerX : tower.x) + TILE_SIZE;
+    let py = (useScreen ? screenTowerY : tower.y) - panelH / 2;
+    if (px + panelW > getCanvasWidth()) px = (useScreen ? screenTowerX : tower.x) - TILE_SIZE - panelW;
     if (px < getGridOffsetX()) px = getGridOffsetX();
     if (py < 0) py = 0;
+    if (py + panelH > getCanvasWidth()) py = getCanvasWidth() - panelH;
 
     this.container.setPosition(px, py);
     this.bg.clear();

--- a/src/ui/TowerSelectBar.ts
+++ b/src/ui/TowerSelectBar.ts
@@ -72,6 +72,17 @@ export class TowerSelectBar {
       zone.on('pointerdown', () => this.highlight(idx));
       zone.on('pointerover', () => this.showTooltip(idx));
       zone.on('pointerout', () => this.hideTooltip());
+      // Touch: long-press shows tooltip (since there's no hover on touch)
+      if (isPhone) {
+        let holdTimer: ReturnType<typeof setTimeout> | null = null;
+        zone.on('pointerdown', () => {
+          holdTimer = setTimeout(() => { this.showTooltip(idx); holdTimer = null; }, 400);
+        });
+        zone.on('pointerup', () => {
+          if (holdTimer) { clearTimeout(holdTimer); holdTimer = null; }
+          this.scene.time.delayedCall(2000, () => this.hideTooltip());
+        });
+      }
 
       if (!isPhone) {
         const hotkeyNum = String(i + 1);


### PR DESCRIPTION
Critical fixes:
- Separate UI camera: HUD elements (depth >= 28) now render on a fixed 1x camera while game world zooms/pans independently. New objects auto-categorized via addedtoscene event.
- CameraController rewrite: pinch-zoom centers on midpoint (not viewport center), totalMoved uses Euclidean distance from start (not accumulated deltas), pan momentum with friction decay, elastic overscroll with snap-back, double-tap to toggle zoom.
- Info panels (TowerInfoPanel, CreepInfoPanel) position in screen coords when camera is zoomed. Depth raised to 29 for UI camera.
- Pause menu already at depth 50 — works correctly on UI camera.

Scene adaptations:
- DraftScene: phone layout with 2-col modifier cards, smaller fonts, adjusted spacing.
- GameOverScene: responsive column positions, smaller fonts on phone, stats table fits within canvas.
- LobbyScene: 3-col factions (from 6), smaller cards and buttons, multi-row map selection on phone.
- EncyclopediaScene: touch drag scrolling alongside mouse wheel.
- ChangelogScene: touch drag scrolling alongside mouse wheel.

UI improvements:
- SendPanel: 26px row height on phone (from 17px), 13px font (from 10px).
- ItemShopPanel: phone-aware font sizing helper, increased row heights.
- TowerSelectBar: long-press (400ms) shows tooltip on touch devices.
- FactionSelectScene: uses ResponsiveManager.isPhone() instead of raw width check.