### PR TITLE
Increase phone scale 2.5x, fix multi-touch, bigger buttons

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -33,6 +33,10 @@ const config: Phaser.Types.Core.GameConfig = {
     antialias: true,
     pixelArt: false,
   },
+  input: {
+    touch: true,
+    activePointers: 3, // support pinch (2 fingers) + 1 extra
+  },
   scale: {
     mode: Phaser.Scale.FIT,
     autoCenter: Phaser.Scale.CENTER_BOTH,

--- a/src/systems/CameraController.ts
+++ b/src/systems/CameraController.ts
@@ -68,10 +68,13 @@ export class CameraController {
   private setupInput(): void {
     if (!ResponsiveManager.isPhone()) return;
 
-    const input = this.scene.input;
+    const scene = this.scene;
 
-    input.on('pointerdown', (pointer: Phaser.Input.Pointer) => {
-      if (input.pointer1.isDown && input.pointer2.isDown) return;
+    scene.input.on('pointerdown', (pointer: Phaser.Input.Pointer) => {
+      // If two pointers are down, let pointermove handle pinch
+      const pointers = scene.input.manager.pointers;
+      const activeCount = pointers.filter(p => p.isDown).length;
+      if (activeCount >= 2) return;
 
       this.isPanning = true;
       this.wasPan = false;
@@ -86,14 +89,16 @@ export class CameraController {
       this.panStartScrollY = this.camera.scrollY;
     });
 
-    input.on('pointermove', (pointer: Phaser.Input.Pointer) => {
+    scene.input.on('pointermove', (pointer: Phaser.Input.Pointer) => {
       // Pinch-to-zoom: two fingers
-      if (input.pointer1.isDown && input.pointer2.isDown) {
+      const pointers = scene.input.manager.pointers;
+      const downPointers = pointers.filter(p => p.isDown);
+      if (downPointers.length >= 2) {
         this.isPanning = false;
         this.pinching = true;
         this.wasPan = true; // suppress click after pinch
-        const p1 = input.pointer1;
-        const p2 = input.pointer2;
+        const p1 = downPointers[0];
+        const p2 = downPointers[1];
         const dist = Math.sqrt((p1.x - p2.x) ** 2 + (p1.y - p2.y) ** 2);
 
         if (this.pinchStartDist === 0) {
@@ -137,7 +142,7 @@ export class CameraController {
       }
     });
 
-    input.on('pointerup', (pointer: Phaser.Input.Pointer) => {
+    scene.input.on('pointerup', (pointer: Phaser.Input.Pointer) => {
       if (this.isPanning && !this.wasPan) {
         // Check double-tap
         const now = Date.now();

--- a/src/systems/UIScale.ts
+++ b/src/systems/UIScale.ts
@@ -57,26 +57,26 @@ const DESKTOP: ScaleValues = {
 };
 
 const PHONE: ScaleValues = {
-  fontTiny: '13px',
-  fontSmall: '15px',
-  fontBody: '17px',
-  fontHeading: '21px',
-  fontTitle: '30px',
-  fontHuge: '42px',
+  fontTiny: '22px',
+  fontSmall: '26px',
+  fontBody: '30px',
+  fontHeading: '38px',
+  fontTitle: '56px',
+  fontHuge: '80px',
 
-  rowHeight: 24,
-  rowHeightTight: 18,
-  sectionGap: 12,
-  padding: 12,
-  paddingSmall: 8,
+  rowHeight: 36,
+  rowHeightTight: 28,
+  sectionGap: 18,
+  padding: 16,
+  paddingSmall: 10,
 
-  btnSize: 62,
-  btnPadding: 6,
-  btnFontSize: '16px',
+  btnSize: 80,
+  btnPadding: 8,
+  btnFontSize: '28px',
 
-  cardGap: 8,
+  cardGap: 12,
 
-  minTouchTarget: 40,
+  minTouchTarget: 60,
 };
 
 class UIScaleClass {
@@ -88,14 +88,16 @@ class UIScaleClass {
   get isPhone(): boolean { return ResponsiveManager.isPhone(); }
 
   // Font helpers that return CSS font size string
+  // Phone canvas is ~1008px displayed on ~400px screen = ~40% physical size
+  // 2.5x scaling makes 12px canvas → 30px canvas → 12px physical (readable)
   font(desktopPx: number): string {
-    const scale = this.isPhone ? 1.4 : 1;
+    const scale = this.isPhone ? 2.5 : 1;
     return `${Math.round(desktopPx * scale)}px`;
   }
 
   // Spacing helper — scales up on phone
   space(desktopPx: number): number {
-    return this.isPhone ? Math.round(desktopPx * 1.3) : desktopPx;
+    return this.isPhone ? Math.round(desktopPx * 2) : desktopPx;
   }
 }
 

--- a/src/ui/TowerSelectBar.ts
+++ b/src/ui/TowerSelectBar.ts
@@ -15,7 +15,7 @@ export class TowerSelectBar {
   private tooltipBg: Phaser.GameObjects.Graphics;
   private tooltipText: Phaser.GameObjects.Text;
 
-  static readonly BAR_HEIGHT = 80; // fits both phone (62px btns) and desktop (52px btns)
+  static readonly BAR_HEIGHT = 96; // fits phone (80px btns) and desktop (52px btns)
   private readonly btnSize: number;
   private readonly padding: number;
 


### PR DESCRIPTION
The 1.4x font scale was way too small — at 40% canvas-to-screen ratio it produced ~7px physical text. Now using 2.5x which gives ~12px physical (readable).

UIScale phone values doubled:
- fontBody: 30px canvas (12px physical)
- fontHeading: 38px canvas (15px physical)
- btnSize: 80px canvas (32px physical)
- minTouchTarget: 60px canvas (24px physical)
- rowHeight: 36px, padding: 16px

Fix multi-touch for pinch-to-zoom:
- Added input.activePointers: 3 in Phaser config (was default 2)
- CameraController now uses scene.input.manager.pointers to find active pointers instead of input.pointer1/pointer2 which may not exist without the config

TowerSelectBar.BAR_HEIGHT increased to 96 for 80px buttons.