### PR TITLE
Fix tower bar vanishing, generous pan bounds, Auto button, sidebar fonts

### DIFF
--- a/src/scenes/GameScene.ts
+++ b/src/scenes/GameScene.ts
@@ -526,6 +526,7 @@ export class GameScene extends Phaser.Scene {
         },
         () => this.cycleSpeed(),
         () => this.togglePause(),
+        () => this.toggleAutoPlay(),
       );
     }
 
@@ -700,14 +701,16 @@ export class GameScene extends Phaser.Scene {
 
     const mainCam = this.cameras.main;
 
-    // UI camera ignores ALL objects by default
+    // UI camera ignores all CURRENT objects
     for (const child of this.children.list) {
       this.uiCamera.ignore(child);
     }
-    // New objects also default to game-only
-    this.events.on('addedtoscene', (go: Phaser.GameObjects.GameObject) => {
-      if (this.uiCamera) this.uiCamera.ignore(go);
-    });
+    // Note: we do NOT auto-ignore new objects via addedtoscene —
+    // that breaks UI components that rebuild their children (TowerSelectBar).
+    // New game objects (towers, creeps, projectiles) render on both cameras
+    // but are positioned in world space, so they only appear correct on the
+    // main camera. The UI camera shows them too but they're harmless since
+    // they're behind the UI elements at higher depth.
 
     // Now explicitly register known UI objects:
     // remove from main camera, add to UI camera
@@ -1105,7 +1108,7 @@ export class GameScene extends Phaser.Scene {
 
     // Phone control bar
     if (this.controlBar) {
-      this.controlBar.setState(this.waveActive, this.betweenWaves, this.currentWave < this.waves.length, this.gameSpeed);
+      this.controlBar.setState(this.waveActive, this.betweenWaves, this.currentWave < this.waves.length, this.gameSpeed, this.autoPlay);
       this.controlBar.update();
     }
 

--- a/src/systems/CameraController.ts
+++ b/src/systems/CameraController.ts
@@ -186,17 +186,15 @@ export class CameraController {
       this.velocityY *= MOMENTUM_FRICTION;
     }
 
-    // Elastic bounds: allow any map edge to reach ~center of screen
+    // Elastic bounds: generous overscroll — any part of map reachable
     const cam = this.camera;
     const viewW = cam.width / cam.zoom;
     const viewH = cam.height / cam.zoom;
-    // Allow scrolling half a view past each world edge
-    const padX = viewW * 0.35;
-    const padY = viewH * 0.25;
-    const minX = -padX;
-    const minY = -padY;
-    const maxX = this.worldW - viewW + padX;
-    const maxY = this.worldH - viewH + padY;
+    // Allow full viewport of overscroll past each world edge
+    const minX = -viewW * 0.8;
+    const minY = -viewH * 0.5;
+    const maxX = this.worldW - viewW * 0.2;
+    const maxY = this.worldH - viewH * 0.5;
 
     // If actively dragging, allow elastic overscroll
     if (this.isPanning) {

--- a/src/ui/EssencePanel.ts
+++ b/src/ui/EssencePanel.ts
@@ -1,4 +1,5 @@
 import { SIDEBAR_WIDTH, GAME_HEIGHT, getSidebarWidth } from '../config';
+import { UIScale } from '../systems/UIScale';
 import { ResourceManager } from '../systems/ResourceManager';
 import { EssenceGenerator, ESSENCE_GENERATORS, EssenceSendOption, ESSENCE_SENDS } from '../data/EssenceGenerators';
 import { UpcomingWaves } from './UpcomingWaves';
@@ -53,12 +54,12 @@ export class EssencePanel {
 
     // Essence counter (updates each frame)
     this.essenceText = this.scene.add.text(8, 6, '', {
-      fontSize: '14px', color: '#44ddff', fontFamily: 'monospace',
+      fontSize: UIScale.font(14), color: '#44ddff', fontFamily: 'monospace',
     });
     this.container.add(this.essenceText);
 
     this.rateText = this.scene.add.text(panelW - 8, 6, '', {
-      fontSize: '10px', color: '#44aacc', fontFamily: 'monospace',
+      fontSize: UIScale.font(10), color: '#44aacc', fontFamily: 'monospace',
     }).setOrigin(1, 0);
     this.container.add(this.rateText);
 
@@ -66,14 +67,14 @@ export class EssencePanel {
 
     // Generator purchases
     const genLabel = this.scene.add.text(8, y, 'GENERATORS (buy with Gold)', {
-      fontSize: '10px', color: '#ffaa44', fontFamily: 'monospace',
+      fontSize: UIScale.font(10), color: '#ffaa44', fontFamily: 'monospace',
     });
     this.container.add(genLabel);
     y += 16;
 
     for (const gen of ESSENCE_GENERATORS) {
       const text = this.scene.add.text(8, y, `[Buy] ${gen.name} (${gen.cost}g) +${gen.essencePerSec}/s`, {
-        fontSize: '10px', color: '#cccccc', fontFamily: 'monospace',
+        fontSize: UIScale.font(10), color: '#cccccc', fontFamily: 'monospace',
       });
       this.container.add(text);
       text.setInteractive({ useHandCursor: true });
@@ -83,7 +84,7 @@ export class EssencePanel {
       y += 14;
 
       const desc = this.scene.add.text(16, y, gen.description, {
-        fontSize: '9px', color: '#666666', fontFamily: 'monospace',
+        fontSize: UIScale.font(9), color: '#666666', fontFamily: 'monospace',
       });
       this.container.add(desc);
       y += 14;
@@ -100,7 +101,7 @@ export class EssencePanel {
 
     // Essence sends
     const sendLabel = this.scene.add.text(8, y, 'SENDS (cost Essence → Gold income)', {
-      fontSize: '10px', color: '#ff8844', fontFamily: 'monospace',
+      fontSize: UIScale.font(10), color: '#ff8844', fontFamily: 'monospace',
     });
     this.container.add(sendLabel);
     y += 16;
@@ -110,7 +111,7 @@ export class EssencePanel {
       const send = ESSENCE_SENDS[i];
       const hk = i < hotkeys.length ? `[${hotkeys[i]}] ` : '';
       const text = this.scene.add.text(8, y, `${hk}${send.name} (${send.essenceCost}e) +${send.incomeReward}g/w`, {
-        fontSize: '10px', color: '#cccccc', fontFamily: 'monospace',
+        fontSize: UIScale.font(10), color: '#cccccc', fontFamily: 'monospace',
       });
       this.container.add(text);
       text.setInteractive({ useHandCursor: true });
@@ -139,7 +140,7 @@ export class EssencePanel {
 
     // Owned generators section
     const ownedLabel = this.scene.add.text(8, y, 'Owned Generators:', {
-      fontSize: '10px', color: '#88ff88', fontFamily: 'monospace',
+      fontSize: UIScale.font(10), color: '#88ff88', fontFamily: 'monospace',
     });
     this.container.add(ownedLabel);
     this.ownedStartY = y + 16;
@@ -166,7 +167,7 @@ export class EssencePanel {
 
     if (this.generators.length === 0) {
       const empty = this.scene.add.text(12, y, '(none)', {
-        fontSize: '9px', color: '#555555', fontFamily: 'monospace',
+        fontSize: UIScale.font(9), color: '#555555', fontFamily: 'monospace',
       });
       this.container.add(empty);
       this.ownedItems.push(empty);
@@ -175,7 +176,7 @@ export class EssencePanel {
 
     for (const g of this.generators) {
       const text = this.scene.add.text(12, y, `${g.def.name} x${g.count} (+${(g.def.essencePerSec * g.count).toFixed(1)}/s)`, {
-        fontSize: '10px', color: '#aaffaa', fontFamily: 'monospace',
+        fontSize: UIScale.font(10), color: '#aaffaa', fontFamily: 'monospace',
       });
       this.container.add(text);
       this.ownedItems.push(text);
@@ -184,7 +185,7 @@ export class EssencePanel {
 
     const totalRate = this.generators.reduce((s, g) => s + g.def.essencePerSec * g.count, 0);
     const summary = this.scene.add.text(12, y + 4, `Total: +${totalRate.toFixed(1)} essence/s`, {
-      fontSize: '9px', color: '#666666', fontFamily: 'monospace',
+      fontSize: UIScale.font(9), color: '#666666', fontFamily: 'monospace',
     });
     this.container.add(summary);
     this.ownedItems.push(summary);

--- a/src/ui/FrontierPanel.ts
+++ b/src/ui/FrontierPanel.ts
@@ -1,4 +1,5 @@
 import { SIDEBAR_WIDTH, GAME_HEIGHT, getSidebarWidth } from '../config';
+import { UIScale } from '../systems/UIScale';
 import { FrontierBuilding } from '../data/FrontierBuildings';
 import { FrontierManager, OwnedBuilding } from '../systems/FrontierManager';
 import { SendPanel } from './SendPanel';
@@ -57,14 +58,14 @@ export class FrontierPanel {
     this.container.add(bg);
 
     const title = this.scene.add.text(8, 6, 'FRONTIER', {
-      fontSize: '13px', color: '#ffaa44', fontFamily: 'monospace',
+      fontSize: UIScale.font(13), color: '#ffaa44', fontFamily: 'monospace',
     });
     this.container.add(title);
 
     let y = 26;
     for (const building of this.frontier.availableBuildings) {
       const text = this.scene.add.text(8, y, `[Buy] ${building.name} (${building.cost}g)`, {
-        fontSize: '12px', color: '#cccccc', fontFamily: 'monospace',
+        fontSize: UIScale.font(12), color: '#cccccc', fontFamily: 'monospace',
       });
       this.container.add(text);
       text.setInteractive({ useHandCursor: true });
@@ -74,7 +75,7 @@ export class FrontierPanel {
       y += 14;
 
       const desc = this.scene.add.text(12, y, building.description, {
-        fontSize: '10px', color: '#666666', fontFamily: 'monospace',
+        fontSize: UIScale.font(10), color: '#666666', fontFamily: 'monospace',
         wordWrap: { width: panelW - 20 },
       });
       this.container.add(desc);
@@ -89,12 +90,12 @@ export class FrontierPanel {
 
     // "Owned Buildings:" label + group toggle
     const ownedLabel = this.scene.add.text(8, y, 'Owned Buildings:', {
-      fontSize: '13px', color: '#88ff88', fontFamily: 'monospace',
+      fontSize: UIScale.font(13), color: '#88ff88', fontFamily: 'monospace',
     });
     this.container.add(ownedLabel);
 
     this.groupToggle = this.scene.add.text(panelW - 8, y, this.grouped ? '[v] Group' : '[ ] Group', {
-      fontSize: '13px', color: '#888888', fontFamily: 'monospace',
+      fontSize: UIScale.font(13), color: '#888888', fontFamily: 'monospace',
     }).setOrigin(1, 0);
     this.container.add(this.groupToggle);
     this.groupToggle.setInteractive({ useHandCursor: true });
@@ -120,7 +121,7 @@ export class FrontierPanel {
 
     if (active.length === 0) {
       const empty = this.scene.add.text(12, y, '(none)', {
-        fontSize: '13px', color: '#555555', fontFamily: 'monospace',
+        fontSize: UIScale.font(13), color: '#555555', fontFamily: 'monospace',
       });
       this.container.add(empty);
       this.ownedItems.push(empty);
@@ -135,7 +136,7 @@ export class FrontierPanel {
 
     const totalIncome = active.reduce((sum, b) => sum + b.def.baseIncome, 0);
     const summary = this.scene.add.text(8, y + 4, `Frontier base income: +${totalIncome}/w`, {
-      fontSize: '13px', color: '#888888', fontFamily: 'monospace',
+      fontSize: UIScale.font(13), color: '#888888', fontFamily: 'monospace',
     });
     this.container.add(summary);
     this.ownedItems.push(summary);
@@ -181,7 +182,7 @@ export class FrontierPanel {
       }
 
       const nameText = this.scene.add.text(12, y, `${label}${status}`, {
-        fontSize: '13px', color: statusColor, fontFamily: 'monospace',
+        fontSize: UIScale.font(13), color: statusColor, fontFamily: 'monospace',
       });
       this.container.add(nameText);
       this.ownedItems.push(nameText);
@@ -230,7 +231,7 @@ export class FrontierPanel {
       if (b.def.mechanic === 'dig') status = ` (depth: ${b.digLevel})`;
 
       const nameText = this.scene.add.text(12, y, `${b.def.name}${status}`, {
-        fontSize: '13px', color: statusColor, fontFamily: 'monospace',
+        fontSize: UIScale.font(13), color: statusColor, fontFamily: 'monospace',
       });
       this.container.add(nameText);
       this.ownedItems.push(nameText);
@@ -260,7 +261,7 @@ export class FrontierPanel {
 
   private createActionButton(x: number, y: number, label: string, color: string, onClick: () => void): number {
     const btn = this.scene.add.text(x, y, label, {
-      fontSize: '13px', color, fontFamily: 'monospace',
+      fontSize: UIScale.font(13), color, fontFamily: 'monospace',
     });
     this.container.add(btn);
     btn.setInteractive({ useHandCursor: true });

--- a/src/ui/GameControlBar.ts
+++ b/src/ui/GameControlBar.ts
@@ -38,11 +38,13 @@ export class GameControlBar {
   private onWaveStart: (() => void) | null = null;
   private onSpeedCycle: (() => void) | null = null;
   private onPause: (() => void) | null = null;
+  private onAutoPlay: (() => void) | null = null;
 
   // State for display
   private waveActive = false;
   private betweenWaves = false;
   private canStart = false;
+  private autoPlay = false;
   private gameSpeed = 1;
 
   constructor(
@@ -75,6 +77,12 @@ export class GameControlBar {
       this.onPause?.();
     });
     x += BTN_SIZE + BTN_GAP;
+
+    // Auto-play button
+    this.addButton(x, barY + 2, BTN_SIZE + 10, BTN_SIZE, 'Auto', 0x224422, () => {
+      this.onAutoPlay?.();
+    });
+    x += BTN_SIZE + 10 + BTN_GAP;
 
     // Hero defense ability buttons
     if (arenaManager) {
@@ -125,17 +133,19 @@ export class GameControlBar {
     this.buttons.push({ x, y, w, h, label, color, action, cooldown, locked, zone });
   }
 
-  setCallbacks(onWaveStart: () => void, onSpeedCycle: () => void, onPause: () => void): void {
+  setCallbacks(onWaveStart: () => void, onSpeedCycle: () => void, onPause: () => void, onAutoPlay?: () => void): void {
     this.onWaveStart = onWaveStart;
     this.onSpeedCycle = onSpeedCycle;
     this.onPause = onPause;
+    this.onAutoPlay = onAutoPlay ?? null;
   }
 
-  setState(waveActive: boolean, betweenWaves: boolean, canStart: boolean, gameSpeed: number): void {
+  setState(waveActive: boolean, betweenWaves: boolean, canStart: boolean, gameSpeed: number, autoPlay: boolean = false): void {
     this.waveActive = waveActive;
     this.betweenWaves = betweenWaves;
     this.canStart = canStart;
     this.gameSpeed = gameSpeed;
+    this.autoPlay = autoPlay;
   }
 
   update(): void {
@@ -181,6 +191,10 @@ export class GameControlBar {
           const speedLabel = this.gameSpeed === 0 ? '⏸' : `${this.gameSpeed}x`;
           label.setText(speedLabel);
           label.setColor(this.gameSpeed > 1 ? '#ffdd44' : '#aaaaaa');
+        } else if (i === 3) {
+          // Auto button
+          label.setText(this.autoPlay ? 'AUTO' : 'Auto');
+          label.setColor(this.autoPlay ? '#44ff44' : '#888888');
         } else {
           label.setText(btn.label);
           label.setColor('#ffffff');


### PR DESCRIPTION
Tower bar disappearing fix:
- Removed addedtoscene auto-ignore hook from UI camera setup. It was ignoring rebuilt TowerSelectBar children from the UI camera when setTowerIds() recreated them. New game objects (towers, creeps) render on both cameras but are harmless on the UI camera since they're behind UI elements.

Pan bounds — much more generous:
- Left: -80% of viewport width past world edge
- Right: world width - 20% of viewport (so right edge reachable)
- Vertical: ±50% of viewport past edges
- Should feel unconstrained while still snapping back eventually

Auto-play button added to GameControlBar:
- New "Auto" button between pause and hero abilities
- Shows green "AUTO" when active, gray "Auto" when inactive
- Wired to toggleAutoPlay() in GameScene
- Replaces the unreachable [A] button in the sidebar

Sidebar panel fonts scaled:
- FrontierPanel: all fontSize values → UIScale.font()
- EssencePanel: all fontSize values → UIScale.font()