### PR TITLE
Fix sidebar click-through, tower overlay, mobile info panels

### DIFF
--- a/src/scenes/GameScene.ts
+++ b/src/scenes/GameScene.ts
@@ -536,6 +536,7 @@ export class GameScene extends Phaser.Scene {
       const canvasH = ResponsiveManager.canvasHeight();
       this.cameraCtrl = new CameraController(this, canvasW, canvasH);
       this.inputMgr.setCameraController(this.cameraCtrl);
+      this.inputMgr.setSidebarCheck(() => this.sidebarOverlay?.isVisible() ?? false);
     }
 
     // Versus mode setup
@@ -705,12 +706,16 @@ export class GameScene extends Phaser.Scene {
     for (const child of this.children.list) {
       this.uiCamera.ignore(child);
     }
-    // Note: we do NOT auto-ignore new objects via addedtoscene —
-    // that breaks UI components that rebuild their children (TowerSelectBar).
-    // New game objects (towers, creeps, projectiles) render on both cameras
-    // but are positioned in world space, so they only appear correct on the
-    // main camera. The UI camera shows them too but they're harmless since
-    // they're behind the UI elements at higher depth.
+    // Auto-ignore new GAME objects (depth < 28) from UI camera.
+    // UI objects (depth >= 28) are NOT ignored — they may be rebuilt
+    // by TowerSelectBar etc. and need to stay visible on UI camera.
+    this.events.on('addedtoscene', (go: Phaser.GameObjects.GameObject) => {
+      if (!this.uiCamera) return;
+      const d = (go as any).depth ?? 0;
+      if (d < 28) {
+        this.uiCamera.ignore(go);
+      }
+    });
 
     // Now explicitly register known UI objects:
     // remove from main camera, add to UI camera

--- a/src/systems/InputManager.ts
+++ b/src/systems/InputManager.ts
@@ -21,6 +21,7 @@ export class InputManager {
   private rawClickCallback: ((x: number, y: number) => void) | null = null;
   private gridRows: number = GRID_ROWS;
   private cameraCtrl: CameraController | null = null;
+  private sidebarVisibleCheck: (() => boolean) | null = null;
 
   // Long-press state for touch
   private longPressTimer: ReturnType<typeof setTimeout> | null = null;
@@ -33,6 +34,8 @@ export class InputManager {
     this.events = events;
 
     scene.input.on('pointermove', (pointer: Phaser.Input.Pointer) => {
+      // Skip if sidebar overlay is open
+      if (this.sidebarVisibleCheck?.()) return;
       // Skip hover if camera is panning or pinching
       if (this.cameraCtrl?.wasPan || this.cameraCtrl?.pinching) return;
 
@@ -52,6 +55,8 @@ export class InputManager {
     });
 
     scene.input.on('pointerdown', (pointer: Phaser.Input.Pointer) => {
+      // Skip if sidebar overlay is open
+      if (this.sidebarVisibleCheck?.()) return;
       const isLeftOrTouch = pointer.leftButtonDown() || pointer.wasTouch;
 
       // Start long-press detection for touch
@@ -84,6 +89,7 @@ export class InputManager {
       this.cancelLongPress();
 
       if (!pointer.wasTouch) return;
+      if (this.sidebarVisibleCheck?.()) return; // sidebar open
       if (this.longPressFired) return; // was a long-press (right-click)
       if (this.cameraCtrl?.wasPan) return; // was a pan gesture
 
@@ -174,6 +180,11 @@ export class InputManager {
   /** Link camera controller for pan-suppression */
   setCameraController(ctrl: CameraController): void {
     this.cameraCtrl = ctrl;
+  }
+
+  /** Set a callback to check if sidebar is visible (blocks game input) */
+  setSidebarCheck(check: () => boolean): void {
+    this.sidebarVisibleCheck = check;
   }
 
   private pointerToGrid(pointer: Phaser.Input.Pointer): GridCoord | null {

--- a/src/ui/CreepInfoPanel.ts
+++ b/src/ui/CreepInfoPanel.ts
@@ -1,5 +1,7 @@
 import { TILE_SIZE, getGridOffsetX, getCanvasWidth } from '../config';
 import { Creep } from '../entities/Creep';
+import { UIScale } from '../systems/UIScale';
+import { ResponsiveManager } from '../systems/ResponsiveManager';
 
 export class CreepInfoPanel {
   private scene: Phaser.Scene;
@@ -18,10 +20,24 @@ export class CreepInfoPanel {
     this.bg = scene.add.graphics();
     this.container.add(this.bg);
 
-    this.nameText = scene.add.text(8, 4, '', { fontSize: '14px', color: '#ff8888', fontFamily: 'monospace' });
-    this.statsText = scene.add.text(8, 20, '', { fontSize: '12px', color: '#ffffff', fontFamily: 'monospace' });
-    this.effectsText = scene.add.text(8, 48, '', { fontSize: '13px', color: '#aaaaaa', fontFamily: 'monospace' });
+    const s = UIScale.current;
+    const pad = s.padding;
+    this.nameText = scene.add.text(pad, pad, '', { fontSize: s.fontHeading, color: '#ff8888', fontFamily: 'monospace' });
+    this.statsText = scene.add.text(pad, pad + UIScale.space(18), '', { fontSize: s.fontBody, color: '#ffffff', fontFamily: 'monospace' });
+    this.effectsText = scene.add.text(pad, pad + UIScale.space(48), '', { fontSize: s.fontBody, color: '#aaaaaa', fontFamily: 'monospace' });
     this.container.add([this.nameText, this.statsText, this.effectsText]);
+
+    // Close button on phone
+    if (UIScale.isPhone) {
+      const closeBtn = scene.add.text(0, 0, '[ Close ]', {
+        fontSize: s.fontBody, color: '#aaaaaa', fontFamily: 'monospace',
+        backgroundColor: '#222222', padding: { x: 16, y: 8 },
+      }).setInteractive({ useHandCursor: true });
+      closeBtn.on('pointerdown', () => this.hide());
+      this.container.add(closeBtn);
+      // Position set in refresh() after panel size is known
+      (this as any)._closeBtn = closeBtn;
+    }
   }
 
   show(creep: Creep): void {
@@ -84,25 +100,32 @@ export class CreepInfoPanel {
     this.effectsText.setText(allEffects.length > 0 ? allEffects.join('\n') : 'No effects');
 
     // Panel size
-    const panelW = 280;
-    const panelH = 52 + allEffects.length * 13 + 8;
+    const rh = UIScale.current.rowHeight;
+    const panelW = UIScale.isPhone ? 700 : 280;
+    const panelH = UIScale.space(52) + allEffects.length * rh + UIScale.space(8);
 
-    // Position near creep — screen coords on phone
-    const cam = this.scene.cameras.main;
-    const sx = (c.x - cam.scrollX) * cam.zoom;
-    const sy = (c.y - cam.scrollY) * cam.zoom;
-    const useScreen = cam.zoom !== 1;
-    let px = (useScreen ? sx : c.x) + TILE_SIZE;
-    let py = (useScreen ? sy : c.y) - panelH / 2;
-    if (px + panelW > getCanvasWidth()) px = (useScreen ? sx : c.x) - TILE_SIZE - panelW;
-    if (px < getGridOffsetX()) px = getGridOffsetX();
-    if (py < 0) py = 0;
+    // Position: centered on phone, near creep on desktop
+    if (UIScale.isPhone) {
+      const cw = getCanvasWidth();
+      const ch = ResponsiveManager.canvasHeight();
+      this.container.setPosition((cw - panelW) / 2, (ch - panelH) / 2 - 50);
+    } else {
+      let px = c.x + TILE_SIZE;
+      let py = c.y - panelH / 2;
+      if (px + panelW > getCanvasWidth()) px = c.x - TILE_SIZE - panelW;
+      if (px < getGridOffsetX()) px = getGridOffsetX();
+      if (py < 0) py = 0;
+      this.container.setPosition(px, py);
+    }
 
-    this.container.setPosition(px, py);
+    // Position close button at bottom of panel
+    const closeBtn = (this as any)._closeBtn;
+    if (closeBtn) closeBtn.setPosition(panelW / 2 - 60, panelH - UIScale.space(20));
+
     this.bg.clear();
     this.bg.fillStyle(0x111111, 0.95);
     this.bg.fillRect(0, 0, panelW, panelH);
-    this.bg.lineStyle(1, 0x884444, 1);
+    this.bg.lineStyle(UIScale.isPhone ? 2 : 1, 0x884444, 1);
     this.bg.strokeRect(0, 0, panelW, panelH);
   }
 

--- a/src/ui/TowerInfoPanel.ts
+++ b/src/ui/TowerInfoPanel.ts
@@ -1,6 +1,8 @@
 import { TILE_SIZE, getGridOffsetX, getCanvasWidth } from '../config';
 import { Tower } from '../entities/Tower';
 import { hasTrait, getTrait } from '../systems/traits/Trait';
+import { UIScale } from '../systems/UIScale';
+import { ResponsiveManager } from '../systems/ResponsiveManager';
 
 export class TowerInfoPanel {
   private scene: Phaser.Scene;
@@ -26,34 +28,43 @@ export class TowerInfoPanel {
     this.bg = scene.add.graphics();
     this.container.add(this.bg);
 
-    this.nameText = scene.add.text(8, 4, '', { fontSize: '13px', color: '#ffdd44', fontFamily: 'monospace' });
-    this.statsText = scene.add.text(8, 22, '', { fontSize: '12px', color: '#ffffff', fontFamily: 'monospace' });
-    this.buffText = scene.add.text(8, 36, '', { fontSize: '12px', color: '#88ff88', fontFamily: 'monospace' });
-    this.traitsText = scene.add.text(8, 50, '', { fontSize: '13px', color: '#aaaaaa', fontFamily: 'monospace' });
-    this.upgradeText = scene.add.text(8, 66, '', { fontSize: '12px', color: '#88ff88', fontFamily: 'monospace' });
+    const s = UIScale.current;
+    const pad = s.padding;
+    this.nameText = scene.add.text(pad, pad, '', { fontSize: s.fontHeading, color: '#ffdd44', fontFamily: 'monospace' });
+    this.statsText = scene.add.text(pad, pad + UIScale.space(18), '', { fontSize: s.fontBody, color: '#ffffff', fontFamily: 'monospace' });
+    this.buffText = scene.add.text(pad, pad + UIScale.space(32), '', { fontSize: s.fontBody, color: '#88ff88', fontFamily: 'monospace' });
+    this.traitsText = scene.add.text(pad, pad + UIScale.space(46), '', { fontSize: s.fontBody, color: '#aaaaaa', fontFamily: 'monospace' });
+    this.upgradeText = scene.add.text(pad, pad + UIScale.space(62), '', { fontSize: s.fontBody, color: '#88ff88', fontFamily: 'monospace' });
     this.container.add([this.nameText, this.statsText, this.buffText, this.traitsText, this.upgradeText]);
 
-    // Tappable action buttons
-    this.upgradeBtn = scene.add.text(8, 0, '[ Upgrade ]', {
-      fontSize: '13px', color: '#44ff44', fontFamily: 'monospace',
-      backgroundColor: '#1a2a1a', padding: { x: 4, y: 2 },
+    // Action buttons
+    const btnPadding = { x: UIScale.space(8), y: UIScale.space(4) };
+    this.upgradeBtn = scene.add.text(pad, 0, '[ Upgrade ]', {
+      fontSize: s.fontHeading, color: '#44ff44', fontFamily: 'monospace',
+      backgroundColor: '#1a2a1a', padding: btnPadding,
     }).setInteractive({ useHandCursor: true });
     this.upgradeBtn.on('pointerdown', () => {
       if (this.currentTower && this.onUpgrade) this.onUpgrade(this.currentTower);
     });
-    this.upgradeBtn.on('pointerover', () => this.upgradeBtn.setColor('#88ff88'));
-    this.upgradeBtn.on('pointerout', () => this.upgradeBtn.setColor('#44ff44'));
     this.container.add(this.upgradeBtn);
 
-    this.sellBtn = scene.add.text(120, 0, '[ Sell ]', {
-      fontSize: '13px', color: '#ff8844', fontFamily: 'monospace',
-      backgroundColor: '#2a1a1a', padding: { x: 4, y: 2 },
+    this.sellBtn = scene.add.text(UIScale.space(120), 0, '[ Sell ]', {
+      fontSize: s.fontHeading, color: '#ff8844', fontFamily: 'monospace',
+      backgroundColor: '#2a1a1a', padding: btnPadding,
     }).setInteractive({ useHandCursor: true });
     this.sellBtn.on('pointerdown', () => {
       if (this.currentTower && this.onSell) this.onSell(this.currentTower);
     });
-    this.sellBtn.on('pointerover', () => this.sellBtn.setColor('#ffbb77'));
-    this.sellBtn.on('pointerout', () => this.sellBtn.setColor('#ff8844'));
+
+    // Close button (phone only)
+    if (UIScale.isPhone) {
+      const closeBtn = scene.add.text(UIScale.space(240), 0, '[ Close ]', {
+        fontSize: s.fontHeading, color: '#aaaaaa', fontFamily: 'monospace',
+        backgroundColor: '#222222', padding: btnPadding,
+      }).setInteractive({ useHandCursor: true });
+      closeBtn.on('pointerdown', () => this.hide());
+      this.container.add(closeBtn);
+    }
     this.container.add(this.sellBtn);
 
     this.rangeCircle = scene.add.graphics().setDepth(19);
@@ -164,27 +175,28 @@ export class TowerInfoPanel {
     this.upgradeBtn.setVisible(tower.canUpgrade());
 
     // Calculate panel size
-    const panelW = 350;
-    const panelH = btnY + 24;
+    const panelW = UIScale.isPhone ? 700 : 350;
+    const panelH = btnY + UIScale.space(24);
 
-    // Position near tower — convert to screen coords on phone (UI camera is at 1x)
-    const cam = this.scene.cameras.main;
-    const screenTowerX = (tower.x - cam.scrollX) * cam.zoom;
-    const screenTowerY = (tower.y - cam.scrollY) * cam.zoom;
-    const useScreen = cam.zoom !== 1; // phone with zoom
+    if (UIScale.isPhone) {
+      // Phone: centered modal dialog
+      const cw = getCanvasWidth();
+      const ch = ResponsiveManager.canvasHeight();
+      this.container.setPosition((cw - panelW) / 2, (ch - panelH) / 2 - 50);
+    } else {
+      // Desktop: position near tower
+      let px = tower.x + TILE_SIZE;
+      let py = tower.y - panelH / 2;
+      if (px + panelW > getCanvasWidth()) px = tower.x - TILE_SIZE - panelW;
+      if (px < getGridOffsetX()) px = getGridOffsetX();
+      if (py < 0) py = 0;
+      this.container.setPosition(px, py);
+    }
 
-    let px = (useScreen ? screenTowerX : tower.x) + TILE_SIZE;
-    let py = (useScreen ? screenTowerY : tower.y) - panelH / 2;
-    if (px + panelW > getCanvasWidth()) px = (useScreen ? screenTowerX : tower.x) - TILE_SIZE - panelW;
-    if (px < getGridOffsetX()) px = getGridOffsetX();
-    if (py < 0) py = 0;
-    if (py + panelH > getCanvasWidth()) py = getCanvasWidth() - panelH;
-
-    this.container.setPosition(px, py);
     this.bg.clear();
     this.bg.fillStyle(0x111111, 0.95);
     this.bg.fillRect(0, 0, panelW, panelH);
-    this.bg.lineStyle(1, 0x555555, 1);
+    this.bg.lineStyle(UIScale.isPhone ? 2 : 1, 0x555555, 1);
     this.bg.strokeRect(0, 0, panelW, panelH);
 
     // Aura buff border


### PR DESCRIPTION
Sidebar click propagation fix:
- InputManager now checks sidebarVisibleCheck() callback before processing any game input (pointermove, pointerdown, pointerup)
- When sidebar overlay is open, all game clicks are blocked

Tower overlay on UI camera fix:
- Re-added addedtoscene hook but only ignores objects with depth < 28 (game objects). Objects at depth >= 28 (UI) are NOT auto-ignored, so TowerSelectBar rebuilds work correctly.

TowerInfoPanel mobile redesign:
- Phone: centered 700px modal dialog with UIScale fonts
- Big Upgrade/Sell/Close buttons using UIScale.current sizing
- All fonts use UIScale.current.fontHeading/fontBody
- No raw isPhone ternaries for font sizes

CreepInfoPanel mobile redesign:
- Phone: centered 700px modal dialog with close button
- All fonts use UIScale.current sizing
- Panel height scales with UIScale.space()