### PR TITLE
Fix tower bar vanishing on Random rotation + relax mobile camera bounds

### DIFF
--- a/src/scenes/GameScene.ts
+++ b/src/scenes/GameScene.ts
@@ -567,6 +567,7 @@ export class GameScene extends Phaser.Scene {
             if (this.faction === 'random') {
               this.activeTowerIds = msg.towerIds;
               this.towerBar.setTowerIds(this.activeTowerIds);
+              this.fixTowerBarCamera();
               this.enterNoneMode();
               this.eventLog.gameMessage('Tower pool updated!');
             }
@@ -775,6 +776,20 @@ export class GameScene extends Phaser.Scene {
       if (id.text) objs.push(id.text);
     }
     return objs.filter(Boolean);
+  }
+
+  /** After tower bar rebuild (Random rotation, versus pool sync),
+   *  re-register its children with the UI camera on phone.
+   *  New children get default cameraFilter from addedtoscene handler
+   *  which incorrectly ignores them (depth 0 < 28). */
+  private fixTowerBarCamera(): void {
+    if (!this.uiCamera || !this.towerBar) return;
+    const container = (this.towerBar as any).container as Phaser.GameObjects.Container;
+    const mainCam = this.cameras.main;
+    for (const child of container.list) {
+      child.cameraFilter &= ~this.uiCamera.id; // visible on UI camera
+      child.cameraFilter |= mainCam.id;         // hidden on main camera
+    }
   }
 
   // === Selection Mode Management ===
@@ -1661,6 +1676,7 @@ export class GameScene extends Phaser.Scene {
     if (this.faction === 'random') {
       this.activeTowerIds = this.rollRandomTowers();
       this.towerBar.setTowerIds(this.activeTowerIds);
+      this.fixTowerBarCamera();
       if (this.gameMode instanceof StandardMode) {
         (this.gameMode as StandardMode).rotateRandomFrontier();
       }

--- a/src/systems/CameraController.ts
+++ b/src/systems/CameraController.ts
@@ -196,11 +196,13 @@ export class CameraController {
     // Bounds: the camera viewport can show any part of the world
     // At high zoom, the viewport is small so scroll range is large
     // At low zoom, the viewport covers most of the world so range is small
-    const margin = 20; // small margin past world edges (in world coords)
-    const minX = -margin;
-    const minY = -margin;
-    const maxX = Math.max(this.worldW - viewW + margin, minX);
-    const maxY = Math.max(this.worldH - viewH + margin, minY);
+    // Very relaxed bounds — allow panning well outside the map (2x world size)
+    const marginX = this.worldW;
+    const marginY = this.worldH;
+    const minX = -marginX;
+    const minY = -marginY;
+    const maxX = Math.max(this.worldW - viewW + marginX, minX);
+    const maxY = Math.max(this.worldH - viewH + marginY, minY);
 
     // If actively dragging, allow elastic overscroll
     if (this.isPanning) {


### PR DESCRIPTION
Tower bar disappearing: When setTowerIds() rebuilds the bar (Random faction rotation, versus pool sync), new child objects get default depth 0. The addedtoscene handler sees depth < 28 and ignores them from the UI camera. Even inside the depth-30 container, Phaser checks each child's individual cameraFilter — so they become invisible. Fix: fixTowerBarCamera() re-registers children after rebuild.

Camera bounds: Relaxed from 20px margin to full world-size margin (2x outside map bounds) so users can freely pan around the map without feeling stuck.