### PR TITLE
Fix mobile camera viewport + gold text visibility

### DIFF
--- a/src/systems/CameraController.ts
+++ b/src/systems/CameraController.ts
@@ -58,6 +58,11 @@ export class CameraController {
 
     // Don't use setBounds — we handle elastic bounds manually
     if (ResponsiveManager.isPhone()) {
+      // Resize main camera viewport to just the game grid area.
+      // The full canvas is much taller (includes tower bar, control bar, etc.)
+      // but those are rendered by the UI camera. Without this, the main camera's
+      // viewport extends into the UI area, causing confusing pan/zoom behavior.
+      this.camera.setViewport(0, 0, worldWidth, worldHeight);
       this.camera.setZoom(DEFAULT_PHONE_ZOOM);
       this.camera.centerOn(worldWidth / 2, worldHeight / 2);
     }

--- a/src/systems/UIOverlay.ts
+++ b/src/systems/UIOverlay.ts
@@ -21,14 +21,14 @@ export class UIOverlay {
     this.livesMode = livesMode;
     const isPhone = UIScale.isPhone;
     // Status bar: use a smaller scale than body text to fit 3 values in a row
-    const fs = UIScale.fontCapped(16, 28);
+    const fs = UIScale.font(14);
     const uiStyle = { fontSize: fs, color: '#ffffff', fontFamily: 'monospace' };
     const baseX = getGridOffsetX();
     const cw = getCanvasWidth();
     // On phone: anchor status bar above the tower bar (near bottom of canvas)
     const canvasH = ResponsiveManager.canvasHeight();
     const barY = isPhone
-      ? canvasH - TowerSelectBar.BAR_HEIGHT - 70 - 36 // above tower bar + control bar + margin
+      ? canvasH - TowerSelectBar.BAR_HEIGHT - 70 - UIScale.current.bottomSafeMargin - 36
       : GAME_HEIGHT + 4;
 
     // Spread columns evenly across available width


### PR DESCRIPTION
Camera: Set main camera viewport to game grid dimensions (1008×728) instead of full canvas height (~2142px on phone). The full canvas includes tower bar / control bar area rendered by the UI camera. Without viewport clipping, the main camera's view extended into the UI zone causing confusing pan/zoom where users got stuck below the map with huge empty space.

Gold text: Use UIScale.font(14) (35px phone) instead of fontCapped(16, 28) so the status bar text is readable on mobile. Also properly account for bottomSafeMargin in positioning.