### PR TITLE
Enhance map editor with editable name and integrate Endless mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## 2026-04-11
 
+### Endless Mode + Streamlined Menu
+- **NEW MODE: Endless** — infinite wave scaling, play until you lose. Random creep faction every 10 waves, boss every 10 waves. HP scales cubically beyond wave 50, speed caps at 3x.
+- **Merged Sprint/Standard/Marathon** into a single "Standard" mode with wave count picker overlay (Quick 15 / Standard 30 / Extended 100).
+- **Menu streamlined** from 8 mode cards to 7. Endless card in orange.
+- GameOver shows "Survived X waves" for Endless instead of "Wave X/Y".
+- Endless skips creep faction select (auto-random since factions rotate).
+
 ### Custom Maps
 - **Custom Maps menu**: browse, import, and play user-created maps from the main menu.
 - **Map editor integration**: "Open Map Editor" button opens `/editor.html` in a new tab for visual map design.

--- a/GAMEMODES.md
+++ b/GAMEMODES.md
@@ -1,49 +1,40 @@
 # Game Modes
 
-## Sprint (15 waves)
+## Standard (15 / 30 / 100 waves)
 
-Quick game with fewer creep types. Good for learning tower synergies and testing new factions.
+The core tower defence experience. Pick your wave count from the overlay: Quick (15), Standard (30), or Extended (100).
 
-- **Waves**: 15 (early-game creep types only — no mages, no flying)
-- **Economy**: Standard gold. Kills + wave income + frontier.
-- **Sends**: Available (Z/X/C/V). Adds extra creeps to your own wave for permanent income bonus.
-- **Win condition**: Survive all 15 waves.
-
----
-
-## Standard (30 waves)
-
-The core experience. All creep types appear progressively. Full economic depth.
-
-- **Waves**: 30. Boss every 10th wave. Mages from wave 18, flying from wave 19. Regenerators from wave 25. Late waves (21+) have themed synergistic compositions.
+- **Waves**: Configurable. Boss every 10th wave. Mages from wave 18, flying from wave 19. Regenerators from wave 25. Late waves (21+) have themed synergistic compositions.
 - **Economy**: Standard gold. Kills + wave income + frontier. Kill gold decays by 1 per 10 waves (5g→4g→3g→2g floor).
-- **Sends**: Available. Income bonus compounds over 30 waves. Costs scale +10% per 5 waves. Tier 2 sends (healer, shielded, flying, regen) unlock at waves 10/15/20.
+- **Sends**: Available (Z/X/C/V). Income bonus compounds over time. Costs scale +10% per 5 waves. Tier 2 sends unlock at waves 10/15/20.
 - **Frontier**: Faction-specific buildings with overcharge/dig/harvest actions.
-- **Difficulty scaling**: HP scales quadratically — waves 1-10 feel familiar, but wave 20+ creeps are significantly tougher. Hard mode is genuinely punishing. Insane mode is probably not winnable.
-- **Win condition**: Survive all 30 waves.
+- **Difficulty scaling**: HP scales quadratically — waves 1-10 feel familiar, but wave 20+ creeps are significantly tougher.
+- **Win condition**: Survive all waves.
 
 ### Strategy Tips
 - First 3 waves are just standard creeps — get your economy started.
 - Invest in frontier buildings early for compound income.
-- Save sends for after wave 10 when income matters most.
 - Build a maze before bosses at waves 10, 20, 30.
 - Waves 25-26 bring regenerators — you need sustained DPS, not burst.
-- Hard mode bosses regenerate HP. You need overwhelming firepower.
 
 ---
 
-## Marathon (Endless)
+## Endless (Infinite)
 
-Infinite scaling. How far can you go?
+Infinite scaling. How far can you survive?
 
-- **Waves**: 100+ (generated). All creep types from wave 20+, regenerators from 25+. HP scales quadratically, speed scales continuously.
-- **Economy**: Standard gold. Same as Standard but the income window is much longer.
-- **Win condition**: None — play until you lose. Score based on wave reached.
+- **Waves**: Generated dynamically in batches, never runs out.
+- **Scaling**: HP scales cubically beyond wave 50. Speed caps at 3x. Creep count increases up to 30 per wave.
+- **Boss**: Every 10 waves.
+- **Creep factions**: Random faction rotation every 10 waves — new visuals and variety as you progress.
+- **Economy**: Standard gold. Same as Standard but the income window is unlimited.
+- **Win condition**: None — play until you lose. Game over shows "Survived X waves".
 
 ### Strategy Tips
 - Long-term income investment pays off massively.
-- Ultimates (600-900g) become essential in late waves.
-- Flying creeps and mages will eventually overwhelm even perfect mazes.
+- Ultimates (600-900g) become essential beyond wave 50.
+- The cubic HP scaling means even perfect mazes eventually fall — it's about how far you get.
+- Faction rotation is cosmetic — creep types/stats don't change with faction.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -65,9 +65,8 @@ See [FACTIONS.md](FACTIONS.md) for detailed tower lists and strategies.
 ## Major Systems
 
 ### Match Modes (8)
-- **Sprint** (15 waves) — Quick game
-- **Standard** (30 waves) — Full experience
-- **Marathon** (Endless) — Infinite scaling
+- **Standard** (15/30/100 waves) — Classic tower defence with wave count picker
+- **Endless** (Infinite) — Scaling HP/speed, random creep faction every 10 waves, play until you fall
 - **Battle** (Dual Economy) — Gold + Essence compound growth loop
 - **Hero Defense** (30 waves) — Control a hero in an arena. 10x creeps, 11 heroes (3 offered per game), leveling (1-15), ultimate abilities (R), item shop, accessory shop (rotating), elite enemies at wave 10/20/30, floating damage numbers.
 - **Faction Gauntlet** (100 waves) — Fight all 10 enemy factions in 10-wave stages on unique themed homeworld maps with 90 animated large structures. Towers reset between stages, frontier persists. Stage scaling ramps difficulty. Maps stored as JSON in `src/data/maps/`.

--- a/gauntlet_structure_editor.tsx
+++ b/gauntlet_structure_editor.tsx
@@ -100,6 +100,7 @@ function autoTileIdx(col: number, row: number, grid: TerrainCell[][], matchType:
 export default function GauntletStructureEditor() {
   const [mapIdx, setMapIdx] = useState(0);
   const [themeOverride, setThemeOverride] = useState<string | null>(null);
+  const [mapName, setMapName] = useState('');
   const [cells, setCells] = useState<TerrainCell[][]>(() => makeGrid('empty'));
   const [entries, setEntries] = useState<Set<string>>(new Set());
   const [exits, setExits] = useState<Set<string>>(new Set());
@@ -160,6 +161,7 @@ export default function GauntletStructureEditor() {
     setExits(new Set(config.exits.map(p => `${p.col},${p.row}`)));
     setPlacements((data.structures || []).map(s => ({ ...s })));
     setSelectedPalette(null); setDragIdx(null); setShowExport(false); setBrush('select');
+    setMapName(config.name);
   }, [mapIdx]);
 
   const themeStructures = LARGE_STRUCTURES[activeTheme] || [];
@@ -415,7 +417,7 @@ export default function GauntletStructureEditor() {
     return JSON.stringify({
       faction: config.faction,
       theme: activeTheme,
-      name: config.name,
+      name: mapName || config.name,
       entries: [...entries].map(k => { const [c, r] = k.split(',').map(Number); return { col: c, row: r }; }),
       exits: [...exits].map(k => { const [c, r] = k.split(',').map(Number); return { col: c, row: r }; }),
       blocked,
@@ -460,6 +462,12 @@ export default function GauntletStructureEditor() {
 
       {/* Controls */}
       <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginBottom: 8, flexWrap: 'wrap' }}>
+        <input
+          value={mapName}
+          onChange={e => setMapName(e.target.value)}
+          placeholder="Map name..."
+          style={{ background: '#222', color: '#ffffff', border: '1px solid #666', padding: '5px 10px', fontFamily: 'monospace', fontSize: 12, width: 140 }}
+        />
         <select value={mapIdx} onChange={e => { setMapIdx(Number(e.target.value)); setThemeOverride(null); }}
           style={{ background: '#222', color: '#aa8844', border: '1px solid #aa8844', padding: '5px 10px', fontFamily: 'monospace', fontSize: 12 }}>
           {GAUNTLET_MAP_CONFIGS.map((c, i) => <option key={i} value={i}>{c.faction} — {c.name}</option>)}
@@ -656,6 +664,8 @@ export default function GauntletStructureEditor() {
                     setEntries(new Set((json.entries || []).map((p: any) => `${p.col},${p.row}`)));
                     setExits(new Set((json.exits || []).map((p: any) => `${p.col},${p.row}`)));
                     setPlacements((json.structures || []).map((s: any) => ({ structureId: s.structureId, col: s.col, row: s.row })));
+                    if (json.name) setMapName(json.name);
+                    if (json.theme && THEME_TILESET[json.theme]) setThemeOverride(json.theme);
                   } catch (e) {
                     alert('Invalid JSON: ' + (e as Error).message);
                   }
@@ -668,7 +678,7 @@ export default function GauntletStructureEditor() {
               const json = exportFullJSON();
               const blob = new Blob([json], { type: 'application/json' });
               const a = document.createElement('a');
-              a.download = `${config.faction}.json`;
+              a.download = `${(mapName || config.name).toLowerCase().replace(/\s+/g, '_')}.json`;
               a.href = URL.createObjectURL(blob);
               a.click();
               URL.revokeObjectURL(a.href);

--- a/src/data/WaveDefinitions.ts
+++ b/src/data/WaveDefinitions.ts
@@ -1,4 +1,4 @@
-export type MatchMode = 'sprint' | 'standard' | 'marathon' | 'battle' | 'hero_defense' | 'circle_coop' | 'gauntlet';
+export type MatchMode = 'standard' | 'endless' | 'battle' | 'hero_defense' | 'circle_coop' | 'gauntlet';
 
 export interface WaveCreepGroup {
   creepType: string;
@@ -138,24 +138,66 @@ function generateStandardWaves(count: number): WaveDefinition[] {
   return waves;
 }
 
-export function getWavesForMode(mode: MatchMode): WaveDefinition[] {
+/** Generate waves for endless mode with aggressive scaling */
+export function generateEndlessWaves(startWave: number, count: number): WaveDefinition[] {
+  const waves: WaveDefinition[] = [];
+  const creepTypes = ['standard', 'fast', 'armored', 'swarm', 'evasive', 'shielded', 'splitter', 'regenerator', 'healer', 'flying', 'group'];
+  const mageTypes = ['mage_armor', 'mage_speed', 'mage_evasion', 'mage_heal'];
+
+  for (let i = 0; i < count; i++) {
+    const waveNum = startWave + i;
+    const baseHp = Math.round(20 + waveNum * 10 + waveNum * waveNum * 0.5 + Math.max(0, waveNum - 50) ** 2 * 0.3);
+    const baseSpeed = Math.min(3.0, 1 + waveNum * 0.015);
+    const creepCount = Math.min(30, 5 + Math.floor(waveNum * 0.5));
+    const interval = Math.max(100, 600 - waveNum * 8);
+
+    // Boss every 10 waves
+    if (waveNum % 10 === 0) {
+      waves.push({
+        wave: waveNum,
+        groups: [{ creepType: 'boss', count: 1, hpScale: baseHp * 2, speedScale: 1 }],
+        spawnInterval: 0,
+        isBoss: true,
+      });
+      continue;
+    }
+
+    const groups: WaveCreepGroup[] = [];
+
+    // Mix of creep types that scales with wave number
+    const availableTypes = creepTypes.slice(0, Math.min(creepTypes.length, 3 + Math.floor(waveNum / 5)));
+    for (const ct of availableTypes) {
+      const count = Math.max(1, Math.floor(creepCount / availableTypes.length));
+      groups.push({ creepType: ct, count, hpScale: baseHp, speedScale: baseSpeed });
+    }
+
+    // Add mages after wave 15
+    if (waveNum >= 15) {
+      groups.push({ creepType: mageTypes[waveNum % mageTypes.length], count: 1 + Math.floor(waveNum / 30), hpScale: baseHp, speedScale: baseSpeed });
+    }
+
+    waves.push({ wave: waveNum, groups, spawnInterval: interval, isBoss: false });
+  }
+
+  return waves;
+}
+
+export function getWavesForMode(mode: MatchMode, waveCount?: number): WaveDefinition[] {
   switch (mode) {
-    case 'sprint':
-      return generateStandardWaves(15);
     case 'standard':
-      return generateStandardWaves(30);
-    case 'marathon':
-      return generateStandardWaves(100);
+      return generateStandardWaves(waveCount ?? 30);
+    case 'endless':
+      return generateEndlessWaves(1, 20); // initial batch; more appended at runtime
     case 'battle':
-      return generateStandardWaves(30); // same wave structure, different economy
+      return generateStandardWaves(waveCount ?? 30); // same wave structure, different economy
     case 'hero_defense':
-      return generateStandardWaves(30).map(w => ({
+      return generateStandardWaves(waveCount ?? 30).map(w => ({
         ...w,
         groups: w.groups.map(g => ({ ...g, count: g.count * 10 })),
         spawnInterval: Math.max(80, Math.round(w.spawnInterval * 0.4)),
       })); // 10x creeps, faster spawns — flood the arena
     case 'circle_coop':
-      return generateStandardWaves(30); // same structure, leaked creeps forward to next player
+      return generateStandardWaves(waveCount ?? 30); // same structure, leaked creeps forward to next player
     case 'gauntlet':
       return generateStandardWaves(10); // placeholder — actual waves come from GauntletMode.getStageWaves()
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -14,6 +14,7 @@ import { EncyclopediaScene } from './scenes/EncyclopediaScene';
 import { HeroSelectScene } from './scenes/HeroSelectScene';
 import { CreepFactionSelectScene } from './scenes/CreepFactionSelectScene';
 import { GauntletPreviewScene } from './scenes/GauntletPreviewScene';
+import { LeaderboardScene } from './scenes/LeaderboardScene';
 import { TowerSelectBar } from './ui/TowerSelectBar';
 
 // Register trait handlers (side-effect imports)
@@ -31,7 +32,7 @@ const config: Phaser.Types.Core.GameConfig = {
   height: gameHeight,
   backgroundColor: '#111111',
   parent: document.body,
-  scene: [MenuScene, FactionSelectScene, CreepFactionSelectScene, DraftScene, GauntletPreviewScene, GameScene, GameOverScene, LobbyScene, CircleLobbyScene, ChangelogScene, EncyclopediaScene, HeroSelectScene, CustomMapScene],
+  scene: [MenuScene, FactionSelectScene, CreepFactionSelectScene, DraftScene, GauntletPreviewScene, GameScene, GameOverScene, LobbyScene, CircleLobbyScene, ChangelogScene, LeaderboardScene, EncyclopediaScene, HeroSelectScene, CustomMapScene],
   render: {
     antialias: true,
     pixelArt: false,

--- a/src/scenes/ChangelogScene.ts
+++ b/src/scenes/ChangelogScene.ts
@@ -6,6 +6,18 @@ import { UIScale } from '../systems/UIScale';
 // In-app changelog — recent changes shown to the player
 const CHANGELOG_ENTRIES = [
   {
+    version: 'v28 — Endless Mode + Streamlined Menu',
+    changes: [
+      'NEW MODE: Endless — infinite scaling, play until you fall',
+      'Random creep faction every 10 waves, boss every 10 waves',
+      'HP scales cubically beyond wave 50 — gets brutal',
+      'Game over shows "Survived X waves" — no victory, only glory',
+      'Sprint/Standard/Marathon merged into one Standard mode',
+      'Wave count picker: Quick (15), Standard (30), Extended (100)',
+      'Menu streamlined from 8 to 7 mode cards',
+    ],
+  },
+  {
     version: 'v27 — Custom Maps',
     changes: [
       'NEW: Custom Maps — create, save, and play your own maps',

--- a/src/scenes/CreepFactionSelectScene.ts
+++ b/src/scenes/CreepFactionSelectScene.ts
@@ -110,6 +110,7 @@ export class CreepFactionSelectScene extends Phaser.Scene {
     this.scene.start('DraftScene', {
       ...data,
       creepFaction,
+      waveCount: data.waveCount,
     });
   }
 }

--- a/src/scenes/DraftScene.ts
+++ b/src/scenes/DraftScene.ts
@@ -20,12 +20,13 @@ export class DraftScene extends Phaser.Scene {
   private dailySeed: boolean = false;
   private creepFaction: FactionId | null = null;
   private customMapDef: MapDefinition | null = null;
+  private waveCount?: number;
 
   constructor() {
     super('DraftScene');
   }
 
-  init(data: { mode: MatchMode; faction: FactionId | null; map: MapId; difficulty?: DifficultyLevel; heroId?: HeroId; randomSeed?: number; dailySeed?: boolean; creepFaction?: FactionId; customMapDef?: MapDefinition }): void {
+  init(data: { mode: MatchMode; faction: FactionId | null; map: MapId; difficulty?: DifficultyLevel; heroId?: HeroId; randomSeed?: number; dailySeed?: boolean; creepFaction?: FactionId; customMapDef?: MapDefinition; waveCount?: number }): void {
     this.matchMode = data.mode;
     this.faction = data.faction;
     this.mapId = data.map;
@@ -35,6 +36,7 @@ export class DraftScene extends Phaser.Scene {
     this.dailySeed = data.dailySeed ?? false;
     this.creepFaction = data.creepFaction ?? null;
     this.customMapDef = data.customMapDef ?? null;
+    this.waveCount = data.waveCount;
   }
 
   create(): void {
@@ -118,6 +120,7 @@ export class DraftScene extends Phaser.Scene {
           dailySeed: this.dailySeed,
           creepFaction: this.creepFaction ?? undefined,
           customMapDef: this.customMapDef ?? undefined,
+          waveCount: this.waveCount,
         });
       });
     }
@@ -142,6 +145,7 @@ export class DraftScene extends Phaser.Scene {
           dailySeed: this.dailySeed,
           creepFaction: this.creepFaction ?? undefined,
           customMapDef: this.customMapDef ?? undefined,
+          waveCount: this.waveCount,
         });
       })
       .on('pointerover', function(this: Phaser.GameObjects.Text) { this.setColor('#aaaaaa'); })

--- a/src/scenes/FactionSelectScene.ts
+++ b/src/scenes/FactionSelectScene.ts
@@ -16,18 +16,20 @@ export class FactionSelectScene extends Phaser.Scene {
   private randomSeed: number = 0;
   private dailySeed: boolean = false;
   private customMapDef: MapDefinition | null = null;
+  private waveCount?: number;
 
   constructor() {
     super('FactionSelectScene');
   }
 
-  init(data: { mode: MatchMode; map?: MapId; difficulty?: DifficultyLevel; randomSeed?: number; dailySeed?: boolean; customMapDef?: MapDefinition }): void {
+  init(data: { mode: MatchMode; map?: MapId; difficulty?: DifficultyLevel; randomSeed?: number; dailySeed?: boolean; customMapDef?: MapDefinition; waveCount?: number }): void {
     this.matchMode = data.mode;
     this.mapId = data.map || 'plains';
     this.difficulty = data.difficulty || 'normal';
     this.randomSeed = data.randomSeed ?? 0;
     this.dailySeed = data.dailySeed ?? false;
     this.customMapDef = data.customMapDef ?? null;
+    this.waveCount = data.waveCount;
   }
 
   create(): void {
@@ -132,12 +134,17 @@ export class FactionSelectScene extends Phaser.Scene {
         card.fillRect(x, y, cardW, 6);
       });
       zone.on('pointerdown', () => {
-        const passData = { mode: this.matchMode, faction: factionId, map: this.mapId, difficulty: this.difficulty, randomSeed: this.randomSeed, dailySeed: this.dailySeed, customMapDef: this.customMapDef ?? undefined };
+        const passData = { mode: this.matchMode, faction: factionId, map: this.mapId, difficulty: this.difficulty, randomSeed: this.randomSeed, dailySeed: this.dailySeed, customMapDef: this.customMapDef ?? undefined, waveCount: this.waveCount };
         if (this.matchMode === 'hero_defense') {
           this.scene.start('HeroSelectScene', passData);
         } else if (this.matchMode === 'gauntlet') {
           // Gauntlet skips creep faction select — it picks per stage
           this.scene.start('DraftScene', passData);
+        } else if (this.matchMode === 'endless') {
+          // Endless skips creep faction select — random creep faction, rotates during play
+          const playable = FACTION_ORDER.filter(f => f !== 'random');
+          const randomCreep = playable[Math.floor(Math.random() * playable.length)];
+          this.scene.start('DraftScene', { ...passData, creepFaction: randomCreep });
         } else {
           this.scene.start('CreepFactionSelectScene', passData);
         }

--- a/src/scenes/GameOverScene.ts
+++ b/src/scenes/GameOverScene.ts
@@ -64,7 +64,7 @@ export class GameOverScene extends Phaser.Scene {
 
     const overviewLines = [
       `Mode: ${data.matchMode}${data.faction ? ` (${data.faction})` : ''}`,
-      `Waves: ${data.wave}/${data.totalWaves}  |  Time: ${minutes}m ${seconds}s`,
+      `Waves: ${data.matchMode === 'endless' || data.totalWaves > 200 ? `Survived ${data.wave} waves` : `${data.wave}/${data.totalWaves}`}  |  Time: ${minutes}m ${seconds}s`,
       `Creeps Killed: ${data.creepsKilled}  |  Leaked: ${data.stats?.creepsLeaked ?? 0}`,
       `Towers Built: ${data.towersBuilt}  |  Gold Remaining: ${data.gold}`,
       `Score: ${score}${score >= highScore ? ' (NEW HIGH!)' : `  |  High: ${highScore}`}`,

--- a/src/scenes/GameOverScene.ts
+++ b/src/scenes/GameOverScene.ts
@@ -4,6 +4,7 @@ import { GameStats } from '../systems/StatsTracker';
 import { TOWER_TYPES } from '../data/TowerTypes';
 import { ResponsiveManager } from '../systems/ResponsiveManager';
 import { UIScale } from '../systems/UIScale';
+import { LeaderboardAPI } from '../systems/LeaderboardAPI';
 
 export interface GameOverData {
   won: boolean;
@@ -14,6 +15,7 @@ export interface GameOverData {
   creepsKilled: number;
   matchMode: string;
   faction: string | null;
+  difficulty: string;
   stats?: GameStats;
   // Versus fields
   isVersus?: boolean;
@@ -265,6 +267,50 @@ export class GameOverScene extends Phaser.Scene {
     menuBtn.on('pointerdown', () => this.scene.start('MenuScene'));
     menuBtn.on('pointerover', () => menuBtn.setColor('#ffffff'));
     menuBtn.on('pointerout', () => menuBtn.setColor('#4488ff'));
+
+    // Leaderboard submit for Endless mode
+    if (data.matchMode === 'endless') {
+      const submitY = btnY - UIScale.space(36);
+      const submitBtn = this.add.text(cx, submitY, '[ Submit Score ]', {
+        fontSize: btnFontSize, color: '#ffcc44', fontFamily: 'monospace',
+        padding: { x: UIScale.space(8), y: UIScale.space(6) },
+      }).setOrigin(0.5).setInteractive({ useHandCursor: true });
+      submitBtn.on('pointerover', () => submitBtn.setColor('#ffffff'));
+      submitBtn.on('pointerout', () => submitBtn.setColor('#ffcc44'));
+      submitBtn.on('pointerdown', () => {
+        const name = window.prompt('Enter your name for the leaderboard:', 'Anonymous');
+        if (!name) return;
+        const trimmedName = name.trim().slice(0, 20) || 'Anonymous';
+        submitBtn.setText('Submitting...').removeInteractive();
+        submitBtn.setColor('#888888');
+        LeaderboardAPI.submitScore(
+          trimmedName,
+          data.wave,
+          data.faction || 'Random',
+          data.difficulty,
+          'endless',
+        ).then((result) => {
+          if (result.success && result.rank != null) {
+            submitBtn.setText(`Score submitted! Rank #${result.rank}`);
+            submitBtn.setColor('#44ff44');
+          } else {
+            submitBtn.setText(`Error: ${result.error || 'Unknown error'}`);
+            submitBtn.setColor('#ff4444');
+          }
+        });
+      });
+
+      // View Leaderboard link
+      const viewY = submitY - UIScale.space(26);
+      const viewBtn = this.add.text(cx, viewY, '[ View Leaderboard ]', {
+        fontSize: UIScale.font(12), color: '#88aacc', fontFamily: 'monospace',
+      }).setOrigin(0.5).setInteractive({ useHandCursor: true });
+      viewBtn.on('pointerover', () => viewBtn.setColor('#ffffff'));
+      viewBtn.on('pointerout', () => viewBtn.setColor('#88aacc'));
+      viewBtn.on('pointerdown', () => {
+        this.scene.start('LeaderboardScene');
+      });
+    }
   }
 
   private saveScore(mode: string, score: number): void {

--- a/src/scenes/GameScene.ts
+++ b/src/scenes/GameScene.ts
@@ -14,8 +14,8 @@ import { SpawnManager } from '../systems/SpawnManager';
 import { InputManager } from '../systems/InputManager';
 import { UIOverlay } from '../systems/UIOverlay';
 import { getTowerType, TOWER_ORDER, TOWER_TYPES, getAllFactionTowerIds } from '../data/TowerTypes';
-import { FactionId, getFaction, FACTIONS } from '../data/Factions';
-import { MatchMode, WaveDefinition, getWavesForMode } from '../data/WaveDefinitions';
+import { FactionId, getFaction, FACTIONS, FACTION_ORDER } from '../data/Factions';
+import { MatchMode, WaveDefinition, getWavesForMode, generateEndlessWaves } from '../data/WaveDefinitions';
 import { MapId, MAPS, MapDefinition } from '../data/Maps';
 import { generateRandomMap, getDailySeed } from '../data/MapGenerator';
 import { DifficultyLevel, DIFFICULTIES, DifficultyHints } from '../data/Difficulty';
@@ -186,10 +186,11 @@ export class GameScene extends Phaser.Scene {
   private _gauntletOrder: FactionId[] | undefined;
   private _gauntletTransitioning: boolean = false;
   private _gauntletHud: Phaser.GameObjects.Text | null = null;
+  private waveCount?: number;
 
   private customMapDef: MapDefinition | null = null;
 
-  init(data: { mode?: MatchMode; faction?: FactionId | null; map?: MapId; modifier?: DraftModifier | null; difficulty?: DifficultyLevel; heroId?: HeroId; randomSeed?: number; dailySeed?: boolean; creepFaction?: FactionId; gauntletOrder?: FactionId[]; customMapDef?: MapDefinition }): void {
+  init(data: { mode?: MatchMode; faction?: FactionId | null; map?: MapId; modifier?: DraftModifier | null; difficulty?: DifficultyLevel; heroId?: HeroId; randomSeed?: number; dailySeed?: boolean; creepFaction?: FactionId; gauntletOrder?: FactionId[]; customMapDef?: MapDefinition; waveCount?: number }): void {
     this.matchMode = data.mode || 'standard';
     this.faction = data.faction ?? null;
     this.mapId = data.map || 'plains';
@@ -199,6 +200,7 @@ export class GameScene extends Phaser.Scene {
     this.dailySeed = data.dailySeed ?? false;
     this.randomSeed = data.randomSeed ?? 0;
     this.creepFaction = data.creepFaction ?? 'arcane';
+    this.waveCount = data.waveCount;
     this._gauntletOrder = (data as any).gauntletOrder ?? undefined;
     this._gauntletTransitioning = false;
     this.generatedMapDef = null;
@@ -332,7 +334,7 @@ export class GameScene extends Phaser.Scene {
     this.mapDef = mapDef;
     const gridRows = this.layout.gridRows !== GRID_ROWS ? this.layout.gridRows : undefined;
     this.grid = new Grid(mapDef, gridRows);
-    this.waves = getWavesForMode(this.matchMode);
+    this.waves = getWavesForMode(this.matchMode, this.waveCount);
     this.recalculatePaths();
 
     // Systems
@@ -1156,7 +1158,7 @@ export class GameScene extends Phaser.Scene {
       return;
     }
 
-    if (this.waveMgr.isComplete() && this.creeps.length === 0) {
+    if (this.waveMgr.isComplete() && this.creeps.length === 0 && this.matchMode !== 'endless') {
       // Gauntlet: stage transition instead of game over
       if (this.matchMode === 'gauntlet' && !this._gauntletTransitioning) {
         const gauntlet = this.gameMode as any;
@@ -1786,6 +1788,22 @@ export class GameScene extends Phaser.Scene {
     this.eventLog.waveCleared(waveNum, this.incomeMgr.getWaveIncome());
     this.statsTracker.recordWaveCompleted();
     this.upcomingWaves.update(waveNum, this.waves);
+
+    // Endless mode: append more waves when running low, rotate creep faction every 10 waves
+    if (this.matchMode === 'endless') {
+      if (this.currentWave >= this.waves.length - 5) {
+        const nextStart = this.waves.length + 1;
+        const newWaves = generateEndlessWaves(nextStart, 10);
+        this.waves.push(...newWaves);
+        console.log(`[Endless] Appended waves ${nextStart}-${nextStart + 9}, total: ${this.waves.length}`);
+      }
+      if (waveNum % 10 === 0) {
+        const playable = FACTION_ORDER.filter(f => f !== 'random' && f !== this.creepFaction);
+        this.creepFaction = playable[Math.floor(Math.random() * playable.length)];
+        console.log(`[Endless] Creep faction rotated to: ${this.creepFaction}`);
+        this.eventLog.gameMessage(`Enemy faction changed to ${FACTIONS[this.creepFaction].name}!`);
+      }
+    }
 
     // Random faction rotation
     if (this.faction === 'random') {

--- a/src/scenes/GameScene.ts
+++ b/src/scenes/GameScene.ts
@@ -1341,6 +1341,7 @@ export class GameScene extends Phaser.Scene {
       creepsKilled: this.creepMgr.totalCreepsKilled,
       matchMode: this.matchMode,
       faction: this.faction,
+      difficulty: this.difficulty,
       stats: this.statsTracker.stats,
       // Versus data
       isVersus: !!this.versus,

--- a/src/scenes/HeroSelectScene.ts
+++ b/src/scenes/HeroSelectScene.ts
@@ -28,6 +28,7 @@ export class HeroSelectScene extends Phaser.Scene {
   private randomSeed: number = 0;
   private dailySeed: boolean = false;
   private customMapDef: MapDefinition | null = null;
+  private waveCount?: number;
   private phoneCardIndex: number = 0;
   private phoneOffered: HeroId[] = [];
 
@@ -35,7 +36,7 @@ export class HeroSelectScene extends Phaser.Scene {
     super('HeroSelectScene');
   }
 
-  init(data: { mode: MatchMode; faction: FactionId | null; map?: MapId; difficulty?: DifficultyLevel; randomSeed?: number; dailySeed?: boolean; customMapDef?: MapDefinition }): void {
+  init(data: { mode: MatchMode; faction: FactionId | null; map?: MapId; difficulty?: DifficultyLevel; randomSeed?: number; dailySeed?: boolean; customMapDef?: MapDefinition; waveCount?: number }): void {
     this.matchMode = data.mode;
     this.faction = data.faction;
     this.mapId = data.map || 'hero_plains';
@@ -43,6 +44,7 @@ export class HeroSelectScene extends Phaser.Scene {
     this.randomSeed = data.randomSeed ?? 0;
     this.dailySeed = data.dailySeed ?? false;
     this.customMapDef = data.customMapDef ?? null;
+    this.waveCount = data.waveCount;
   }
 
   preload(): void {
@@ -385,6 +387,7 @@ export class HeroSelectScene extends Phaser.Scene {
       randomSeed: this.randomSeed,
       dailySeed: this.dailySeed,
       customMapDef: this.customMapDef ?? undefined,
+      waveCount: this.waveCount,
     });
   }
 }

--- a/src/scenes/LeaderboardScene.ts
+++ b/src/scenes/LeaderboardScene.ts
@@ -1,0 +1,216 @@
+import Phaser from 'phaser';
+import { getCanvasWidth } from '../config';
+import { ResponsiveManager } from '../systems/ResponsiveManager';
+import { UIScale } from '../systems/UIScale';
+import { LeaderboardAPI, LeaderboardEntry } from '../systems/LeaderboardAPI';
+
+export class LeaderboardScene extends Phaser.Scene {
+  private scrollY: number = 0;
+  private contentHeight: number = 0;
+  private isDragging: boolean = false;
+  private dragStartY: number = 0;
+  private dragStartScrollY: number = 0;
+  private contentContainer: Phaser.GameObjects.Container | null = null;
+  private contentAreaY: number = 0;
+  private contentAreaH: number = 0;
+
+  constructor() {
+    super('LeaderboardScene');
+  }
+
+  create(data?: { highlightWave?: number; highlightName?: string }): void {
+    const cx = getCanvasWidth() / 2;
+    const totalH = ResponsiveManager.canvasHeight();
+
+    this.scrollY = 0;
+
+    // Background
+    this.add.graphics().fillStyle(0x0a0a0f, 1).fillRect(0, 0, getCanvasWidth(), totalH);
+
+    // Title
+    this.add.text(cx, UIScale.space(25), 'LEADERBOARD', {
+      fontSize: UIScale.font(28), color: '#ffcc44', fontFamily: 'monospace',
+    }).setOrigin(0.5);
+
+    // Back button
+    const backBtn = this.add.text(UIScale.space(50), UIScale.space(25), '[ Back ]', {
+      fontSize: UIScale.font(14), color: '#888888', fontFamily: 'monospace',
+    }).setInteractive({ useHandCursor: true });
+    backBtn.on('pointerdown', () => this.scene.start('MenuScene'));
+    backBtn.on('pointerover', () => backBtn.setColor('#ffffff'));
+    backBtn.on('pointerout', () => backBtn.setColor('#888888'));
+
+    // Scrollable content area
+    this.contentAreaY = UIScale.space(65);
+    this.contentAreaH = totalH - UIScale.space(75);
+
+    const mask = this.add.graphics();
+    mask.fillRect(0, this.contentAreaY, getCanvasWidth(), this.contentAreaH);
+    const maskGeo = mask.createGeometryMask();
+
+    this.contentContainer = this.add.container(0, this.contentAreaY);
+    this.contentContainer.setMask(maskGeo);
+
+    // Loading text
+    const loadingText = this.add.text(cx, UIScale.space(80), 'Loading scores...', {
+      fontSize: UIScale.font(14), color: '#888888', fontFamily: 'monospace',
+    }).setOrigin(0.5);
+    this.contentContainer.add(loadingText);
+
+    // Fetch scores
+    LeaderboardAPI.getScores('endless', 50).then((scores) => {
+      this.contentContainer?.removeAll(true);
+      if (scores.length === 0) {
+        this.showEmpty();
+        return;
+      }
+      this.buildScoreList(scores, data);
+    }).catch(() => {
+      this.contentContainer?.removeAll(true);
+      this.showError();
+    });
+
+    // Scroll with mouse wheel
+    this.input.on('wheel', (_pointer: any, _gameObjects: any, _deltaX: number, deltaY: number) => {
+      this.updateScroll(this.scrollY - deltaY * 0.5);
+    });
+
+    // Touch drag scrolling
+    this.input.on('pointerdown', (pointer: Phaser.Input.Pointer) => {
+      this.isDragging = true;
+      this.dragStartY = pointer.y;
+      this.dragStartScrollY = this.scrollY;
+    });
+    this.input.on('pointermove', (pointer: Phaser.Input.Pointer) => {
+      if (!this.isDragging) return;
+      const dy = pointer.y - this.dragStartY;
+      this.updateScroll(this.dragStartScrollY + dy);
+    });
+    this.input.on('pointerup', () => { this.isDragging = false; });
+  }
+
+  private updateScroll(newY: number): void {
+    this.scrollY = Phaser.Math.Clamp(
+      newY,
+      -(this.contentHeight - this.contentAreaH + 20),
+      0,
+    );
+    this.contentContainer?.setY(this.contentAreaY + this.scrollY);
+  }
+
+  private showEmpty(): void {
+    if (!this.contentContainer) return;
+    const cx = getCanvasWidth() / 2;
+    this.contentContainer.add(
+      this.add.text(cx, UIScale.space(80), 'No scores yet. Be the first!', {
+        fontSize: UIScale.font(14), color: '#888888', fontFamily: 'monospace',
+      }).setOrigin(0.5)
+    );
+    this.contentHeight = UIScale.space(160);
+  }
+
+  private showError(): void {
+    if (!this.contentContainer) return;
+    const cx = getCanvasWidth() / 2;
+    this.contentContainer.add(
+      this.add.text(cx, UIScale.space(80), 'Failed to load leaderboard.\nCheck your connection and try again.', {
+        fontSize: UIScale.font(14), color: '#ff4444', fontFamily: 'monospace',
+        align: 'center',
+      }).setOrigin(0.5)
+    );
+    this.contentHeight = UIScale.space(160);
+  }
+
+  private buildScoreList(scores: LeaderboardEntry[], data?: { highlightWave?: number; highlightName?: string }): void {
+    if (!this.contentContainer) return;
+    const cx = getCanvasWidth() / 2;
+    const marginL = UIScale.space(40);
+    const rowH = UIScale.space(20);
+
+    // Column positions
+    const colRank = marginL;
+    const colName = marginL + UIScale.space(50);
+    const colWave = marginL + UIScale.space(210);
+    const colFaction = marginL + UIScale.space(310);
+    const colDiff = marginL + UIScale.space(460);
+
+    let y = UIScale.space(10);
+
+    // Subtitle
+    this.contentContainer.add(
+      this.add.text(cx, y, 'Endless Mode  --  Top 50', {
+        fontSize: UIScale.font(12), color: '#888888', fontFamily: 'monospace',
+      }).setOrigin(0.5)
+    );
+    y += UIScale.space(24);
+
+    // Header
+    const headerColor = '#666666';
+    const headerFont = UIScale.font(11);
+    const headers: [number, string][] = [
+      [colRank, '#'],
+      [colName, 'Name'],
+      [colWave, 'Wave'],
+      [colFaction, 'Faction'],
+      [colDiff, 'Difficulty'],
+    ];
+    for (const [hx, label] of headers) {
+      this.contentContainer.add(
+        this.add.text(hx, y, label, {
+          fontSize: headerFont, color: headerColor, fontFamily: 'monospace',
+        })
+      );
+    }
+    y += UIScale.space(6);
+
+    // Divider
+    const divG = this.add.graphics();
+    divG.lineStyle(1, 0x444444, 0.5);
+    divG.lineBetween(marginL, y, getCanvasWidth() - marginL, y);
+    this.contentContainer.add(divG);
+    y += UIScale.space(8);
+
+    // Rows
+    for (let i = 0; i < scores.length; i++) {
+      const entry = scores[i];
+      const rank = i + 1;
+
+      // Highlight the player's own score if just submitted
+      const isHighlight = data?.highlightName && data?.highlightWave
+        && entry.name === data.highlightName
+        && entry.wave === data.highlightWave;
+
+      const rowColor = isHighlight ? '#ffcc44' : rank <= 3 ? '#ffaa44' : '#cccccc';
+      const rankStr = rank <= 3 ? ['1st', '2nd', '3rd'][rank - 1] : `${rank}.`;
+
+      const fields: [number, string][] = [
+        [colRank, rankStr],
+        [colName, entry.name.length > 16 ? entry.name.slice(0, 15) + '...' : entry.name],
+        [colWave, `Wave ${entry.wave}`],
+        [colFaction, entry.faction],
+        [colDiff, entry.difficulty],
+      ];
+
+      for (const [fx, text] of fields) {
+        this.contentContainer.add(
+          this.add.text(fx, y, text, {
+            fontSize: UIScale.font(12), color: rowColor, fontFamily: 'monospace',
+          })
+        );
+      }
+
+      // Highlight bar behind the row
+      if (isHighlight) {
+        const highlightBar = this.add.graphics();
+        highlightBar.fillStyle(0xffcc44, 0.08);
+        highlightBar.fillRect(marginL - UIScale.space(4), y - UIScale.space(2), getCanvasWidth() - marginL * 2 + UIScale.space(8), rowH);
+        this.contentContainer.add(highlightBar);
+      }
+
+      y += rowH;
+    }
+
+    y += UIScale.space(20);
+    this.contentHeight = y;
+  }
+}

--- a/src/scenes/MenuScene.ts
+++ b/src/scenes/MenuScene.ts
@@ -22,6 +22,7 @@ export class MenuScene extends Phaser.Scene {
   private dailyToggle: Phaser.GameObjects.Text | null = null;
   private mapButtons: { btn: Phaser.GameObjects.Graphics; id: MapId; x: number; y: number; w: number; h: number }[] = [];
   private diffButtons: { btn: Phaser.GameObjects.Graphics; id: DifficultyLevel; x: number; y: number; w: number; h: number }[] = [];
+  private waveCountOverlay: Phaser.GameObjects.Container | null = null;
 
   constructor() {
     super('MenuScene');
@@ -141,23 +142,22 @@ export class MenuScene extends Phaser.Scene {
     }).setOrigin(0.5);
     yPos += UIScale.y(20);
 
-    const goFaction = (mode: MatchMode) => {
+    const goFaction = (mode: MatchMode, waveCount?: number) => {
       const seed = this.selectedMap === 'random'
         ? (this.dailySeed ? getDailySeed() : Math.floor(Math.random() * 999999999))
         : 0;
       this.scene.start('FactionSelectScene', {
         mode, map: this.selectedMap, difficulty: this.selectedDifficulty,
-        randomSeed: seed, dailySeed: this.dailySeed,
+        randomSeed: seed, dailySeed: this.dailySeed, waveCount,
       });
     };
 
     const modes: ModeCard[] = [
-      { label: 'Sprint',          desc: '15 waves — quick game',            accent: 0x44cc44, action: () => goFaction('sprint') },
-      { label: 'Standard',        desc: '30 waves — full experience',       accent: 0x44cc44, action: () => goFaction('standard') },
-      { label: 'Marathon',         desc: 'Endless — infinite scaling',       accent: 0x44cc44, action: () => goFaction('marathon') },
+      { label: 'Standard',         desc: 'Classic tower defence',           accent: 0x44cc44, action: () => this.showWaveCountOverlay(goFaction) },
       { label: 'Battle',           desc: 'Dual economy — Gold + Essence',   accent: 0xddaa22, action: () => goFaction('battle') },
       { label: 'Hero Defense',     desc: 'Control a hero in the arena',     accent: 0xff44aa, action: () => goFaction('hero_defense') },
       { label: 'Faction Gauntlet', desc: '100 waves — fight all factions',  accent: 0xff4444, action: () => goFaction('gauntlet') },
+      { label: 'Endless',          desc: 'Infinite scaling — play until you fall', accent: 0xff6622, action: () => goFaction('endless') },
       { label: 'Versus 1v1',       desc: 'P2P competitive — sends attack',  accent: 0xff8844, action: () => this.scene.start('LobbyScene') },
       { label: 'Circle Co-op',     desc: '2-4 players — shared map',        accent: 0x44aaff, action: () => this.scene.start('CircleLobbyScene') },
     ];
@@ -233,6 +233,123 @@ export class MenuScene extends Phaser.Scene {
     this.add.text(getCanvasWidth() - 8, totalH - 8, `v${__GIT_SHA__}`, {
       fontSize: UIScale.font(10), color: '#666666', fontFamily: 'monospace',
     }).setOrigin(1, 1);
+  }
+
+  private showWaveCountOverlay(goFaction: (mode: MatchMode, waveCount?: number) => void): void {
+    if (this.waveCountOverlay) return;
+
+    const canvasW = getCanvasWidth();
+    const totalH = GAME_HEIGHT + 28 + TowerSelectBar.BAR_HEIGHT;
+
+    const container = this.add.container(0, 0);
+    container.setDepth(1000);
+
+    // Semi-transparent dark background
+    const bg = this.add.graphics();
+    bg.fillStyle(0x000000, 0.7);
+    bg.fillRect(0, 0, canvasW, totalH);
+    container.add(bg);
+
+    // Click-outside to dismiss
+    const bgZone = this.add.zone(canvasW / 2, totalH / 2, canvasW, totalH).setInteractive();
+    bgZone.on('pointerdown', () => this.dismissWaveCountOverlay());
+    container.add(bgZone);
+
+    // Panel dimensions
+    const panelW = UIScale.isPhone ? 800 : 420;
+    const panelH = UIScale.isPhone ? 400 : 260;
+    const panelX = (canvasW - panelW) / 2;
+    const panelY = (totalH - panelH) / 2;
+
+    // Panel background
+    const panel = this.add.graphics();
+    panel.fillStyle(0x1e1e28, 1);
+    panel.fillRect(panelX, panelY, panelW, panelH);
+    panel.lineStyle(2, 0xccaa44, 0.8);
+    panel.strokeRect(panelX, panelY, panelW, panelH);
+    container.add(panel);
+
+    // Block clicks on panel from reaching bgZone
+    const panelZone = this.add.zone(panelX + panelW / 2, panelY + panelH / 2, panelW, panelH).setInteractive();
+    container.add(panelZone);
+
+    // Title
+    const title = this.add.text(canvasW / 2, panelY + UIScale.y(28), 'Select Wave Count', {
+      fontSize: UIScale.font(18), color: '#ffffff', fontFamily: 'monospace',
+    }).setOrigin(0.5);
+    container.add(title);
+
+    // Wave count options
+    const options: { label: string; waves: number; desc: string }[] = [
+      { label: 'Quick', waves: 15, desc: '15 waves' },
+      { label: 'Standard', waves: 30, desc: '30 waves' },
+      { label: 'Extended', waves: 100, desc: '100 waves' },
+    ];
+
+    const btnW = UIScale.isPhone ? 220 : 120;
+    const btnH = UIScale.isPhone ? 100 : 70;
+    const btnGap = UIScale.isPhone ? 16 : 12;
+    const totalBtnW = options.length * btnW + (options.length - 1) * btnGap;
+    const btnStartX = canvasW / 2 - totalBtnW / 2;
+    const btnY = panelY + UIScale.y(70);
+
+    for (let i = 0; i < options.length; i++) {
+      const opt = options[i];
+      const bx = btnStartX + i * (btnW + btnGap);
+      const by = btnY;
+
+      const btnGfx = this.add.graphics();
+      const drawBtn = (hover: boolean) => {
+        btnGfx.clear();
+        btnGfx.fillStyle(hover ? 0x3a3a44 : 0x2a2a33, 1);
+        btnGfx.fillRect(bx, by, btnW, btnH);
+        btnGfx.lineStyle(2, hover ? 0xffffff : 0xccaa44, hover ? 1 : 0.6);
+        btnGfx.strokeRect(bx, by, btnW, btnH);
+        // Accent strip
+        btnGfx.fillStyle(0x44cc44, hover ? 0.9 : 0.5);
+        btnGfx.fillRect(bx, by, 4, btnH);
+      };
+      drawBtn(false);
+      container.add(btnGfx);
+
+      const labelText = this.add.text(bx + btnW / 2, by + UIScale.y(20), opt.label, {
+        fontSize: UIScale.font(14), color: '#ffffff', fontFamily: 'monospace',
+      }).setOrigin(0.5);
+      container.add(labelText);
+
+      const descText = this.add.text(bx + btnW / 2, by + UIScale.y(42), opt.desc, {
+        fontSize: UIScale.font(11), color: '#888888', fontFamily: 'monospace',
+      }).setOrigin(0.5);
+      container.add(descText);
+
+      const btnZone = this.add.zone(bx + btnW / 2, by + btnH / 2, btnW, btnH).setInteractive({ useHandCursor: true });
+      btnZone.on('pointerover', () => drawBtn(true));
+      btnZone.on('pointerout', () => drawBtn(false));
+      btnZone.on('pointerdown', () => {
+        this.dismissWaveCountOverlay();
+        goFaction('standard', opt.waves);
+      });
+      container.add(btnZone);
+    }
+
+    // Cancel button
+    const cancelY = btnY + btnH + UIScale.y(24);
+    const cancelText = this.add.text(canvasW / 2, cancelY, '[ Cancel ]', {
+      fontSize: UIScale.font(13), color: '#888888', fontFamily: 'monospace',
+    }).setOrigin(0.5).setInteractive({ useHandCursor: true });
+    cancelText.on('pointerover', () => cancelText.setColor('#ffffff'));
+    cancelText.on('pointerout', () => cancelText.setColor('#888888'));
+    cancelText.on('pointerdown', () => this.dismissWaveCountOverlay());
+    container.add(cancelText);
+
+    this.waveCountOverlay = container;
+  }
+
+  private dismissWaveCountOverlay(): void {
+    if (this.waveCountOverlay) {
+      this.waveCountOverlay.destroy();
+      this.waveCountOverlay = null;
+    }
   }
 
   private drawDiffButtons(): void {

--- a/src/scenes/MenuScene.ts
+++ b/src/scenes/MenuScene.ts
@@ -212,16 +212,24 @@ export class MenuScene extends Phaser.Scene {
       fontSize: UIScale.font(10), color: '#555555', fontFamily: 'monospace',
     }).setOrigin(0.5);
 
-    // Encyclopedia + Changelog buttons
+    // Encyclopedia + Leaderboard + Changelog buttons
     const bottomRowY = gridStartY + modeRows * (cardH + gapY) + 18;
-    const encBtn = this.add.text(cx - 120, bottomRowY, '[ Encyclopedia ]', {
+    const bottomSpacing = ph ? 160 : 130;
+    const encBtn = this.add.text(cx - bottomSpacing, bottomRowY, '[ Encyclopedia ]', {
       fontSize: UIScale.font(13), color: '#88aacc', fontFamily: 'monospace',
     }).setOrigin(0.5).setInteractive({ useHandCursor: true });
     encBtn.on('pointerdown', () => this.scene.start('EncyclopediaScene'));
     encBtn.on('pointerover', () => encBtn.setColor('#bbddff'));
     encBtn.on('pointerout', () => encBtn.setColor('#88aacc'));
 
-    const logBtn = this.add.text(cx + 120, bottomRowY, '[ Changelog ]', {
+    const lbBtn = this.add.text(cx, bottomRowY, '[ Leaderboard ]', {
+      fontSize: UIScale.font(13), color: '#ffcc44', fontFamily: 'monospace',
+    }).setOrigin(0.5).setInteractive({ useHandCursor: true });
+    lbBtn.on('pointerdown', () => this.scene.start('LeaderboardScene'));
+    lbBtn.on('pointerover', () => lbBtn.setColor('#ffeeaa'));
+    lbBtn.on('pointerout', () => lbBtn.setColor('#ffcc44'));
+
+    const logBtn = this.add.text(cx + bottomSpacing, bottomRowY, '[ Changelog ]', {
       fontSize: UIScale.font(13), color: '#88aacc', fontFamily: 'monospace',
     }).setOrigin(0.5).setInteractive({ useHandCursor: true });
     logBtn.on('pointerdown', () => this.scene.start('ChangelogScene'));

--- a/src/systems/LeaderboardAPI.ts
+++ b/src/systems/LeaderboardAPI.ts
@@ -1,4 +1,4 @@
-const API_URL = 'https://td-leaderboard.alex-hughes.workers.dev';
+const API_URL = 'https://signal.streamingsplats.com';
 
 export interface LeaderboardEntry {
   id: string;

--- a/src/systems/LeaderboardAPI.ts
+++ b/src/systems/LeaderboardAPI.ts
@@ -1,0 +1,50 @@
+const API_URL = 'https://td-leaderboard.alex-hughes.workers.dev';
+
+export interface LeaderboardEntry {
+  id: string;
+  name: string;
+  wave: number;
+  faction: string;
+  difficulty: string;
+  mode: string;
+  timestamp: number;
+}
+
+export class LeaderboardAPI {
+  static async getScores(mode?: string, limit?: number): Promise<LeaderboardEntry[]> {
+    try {
+      const params = new URLSearchParams();
+      if (mode) params.set('mode', mode);
+      if (limit) params.set('limit', String(limit));
+      const qs = params.toString();
+      const url = `${API_URL}/scores${qs ? `?${qs}` : ''}`;
+      const res = await fetch(url);
+      if (!res.ok) return [];
+      return await res.json();
+    } catch (_) {
+      return [];
+    }
+  }
+
+  static async submitScore(
+    name: string,
+    wave: number,
+    faction: string,
+    difficulty: string,
+    mode: string,
+  ): Promise<{ success: boolean; rank?: number; error?: string }> {
+    try {
+      const res = await fetch(`${API_URL}/scores`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name, wave, faction, difficulty, mode }),
+      });
+      if (!res.ok) {
+        return { success: false, error: `Server error (${res.status})` };
+      }
+      return await res.json();
+    } catch (err) {
+      return { success: false, error: 'Network error — could not reach leaderboard server' };
+    }
+  }
+}

--- a/src/systems/modes/StandardMode.ts
+++ b/src/systems/modes/StandardMode.ts
@@ -10,7 +10,7 @@ for (const opt of SEND_OPTIONS) SEND_OPTIONS_MAP[opt.id] = opt;
 
 /**
  * Standard game mode: gold-based sends, frontier buildings.
- * Used for Sprint, Standard, and Marathon.
+ * Used for Standard and Endless modes.
  */
 export class StandardMode extends BaseFrontierMode {
   readonly id: MatchMode;

--- a/worker/leaderboard.ts
+++ b/worker/leaderboard.ts
@@ -1,0 +1,193 @@
+/**
+ * Cloudflare Worker — Tower Defence Leaderboard
+ *
+ * KV namespace binding: SCORES
+ * Keys:
+ *   "leaderboard"  — JSON array of Score objects, sorted by wave desc, max 500
+ *   "rate:{ip}"    — last-submit timestamp string, TTL 60s
+ */
+
+interface Env {
+  SCORES: KVNamespace;
+}
+
+interface Score {
+  id: string;
+  name: string;
+  wave: number;
+  faction: string;
+  difficulty: string;
+  mode: string;
+  timestamp: string;
+}
+
+interface SubmitBody {
+  name?: unknown;
+  wave?: unknown;
+  faction?: unknown;
+  difficulty?: unknown;
+  mode?: unknown;
+}
+
+const CORS_HEADERS: Record<string, string> = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
+  'Access-Control-Allow-Headers': 'Content-Type',
+  'Access-Control-Max-Age': '86400',
+};
+
+const MAX_STORED = 500;
+const DEFAULT_LIMIT = 100;
+const RATE_LIMIT_SECONDS = 60;
+const VALID_MODES = ['endless'];
+const NAME_REGEX = /^[a-zA-Z0-9 ]{1,20}$/;
+
+function json(data: unknown, status = 200): Response {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { 'Content-Type': 'application/json', ...CORS_HEADERS },
+  });
+}
+
+function errorResponse(message: string, status = 400): Response {
+  return json({ error: message }, status);
+}
+
+function generateUUID(): string {
+  const bytes = crypto.getRandomValues(new Uint8Array(16));
+  bytes[6] = (bytes[6] & 0x0f) | 0x40; // version 4
+  bytes[8] = (bytes[8] & 0x3f) | 0x80; // variant 1
+  const hex = [...bytes].map((b) => b.toString(16).padStart(2, '0')).join('');
+  return [
+    hex.slice(0, 8),
+    hex.slice(8, 12),
+    hex.slice(12, 16),
+    hex.slice(16, 20),
+    hex.slice(20, 32),
+  ].join('-');
+}
+
+async function getLeaderboard(kv: KVNamespace): Promise<Score[]> {
+  const raw = await kv.get('leaderboard');
+  if (!raw) return [];
+  try {
+    return JSON.parse(raw) as Score[];
+  } catch {
+    return [];
+  }
+}
+
+async function handleGetScores(url: URL, env: Env): Promise<Response> {
+  const mode = url.searchParams.get('mode');
+  const limitParam = url.searchParams.get('limit');
+  const limit = limitParam ? Math.min(Math.max(1, parseInt(limitParam, 10) || DEFAULT_LIMIT), MAX_STORED) : DEFAULT_LIMIT;
+
+  let scores = await getLeaderboard(env.SCORES);
+
+  if (mode) {
+    scores = scores.filter((s) => s.mode === mode);
+  }
+
+  scores = scores.slice(0, limit);
+
+  return json({ scores });
+}
+
+async function handlePostScore(request: Request, env: Env): Promise<Response> {
+  // Rate limit by IP
+  const ip = request.headers.get('CF-Connecting-IP') || 'unknown';
+  const rateKey = `rate:${ip}`;
+  const lastSubmit = await env.SCORES.get(rateKey);
+
+  if (lastSubmit) {
+    const elapsed = Date.now() - parseInt(lastSubmit, 10);
+    if (elapsed < RATE_LIMIT_SECONDS * 1000) {
+      const wait = Math.ceil((RATE_LIMIT_SECONDS * 1000 - elapsed) / 1000);
+      return errorResponse(`Rate limited. Try again in ${wait} seconds.`, 429);
+    }
+  }
+
+  // Parse and validate body
+  let body: SubmitBody;
+  try {
+    body = (await request.json()) as SubmitBody;
+  } catch {
+    return errorResponse('Invalid JSON body.');
+  }
+
+  const { name, wave, faction, difficulty, mode } = body;
+
+  if (typeof name !== 'string' || !NAME_REGEX.test(name)) {
+    return errorResponse('Name must be 1-20 alphanumeric characters (spaces allowed).');
+  }
+  if (typeof wave !== 'number' || !Number.isInteger(wave) || wave < 1 || wave > 9999) {
+    return errorResponse('Wave must be an integer between 1 and 9999.');
+  }
+  if (typeof faction !== 'string' || faction.length === 0 || faction.length > 50) {
+    return errorResponse('Faction is required.');
+  }
+  if (typeof difficulty !== 'string' || difficulty.length === 0 || difficulty.length > 50) {
+    return errorResponse('Difficulty is required.');
+  }
+  if (typeof mode !== 'string' || !VALID_MODES.includes(mode)) {
+    return errorResponse(`Mode must be one of: ${VALID_MODES.join(', ')}.`);
+  }
+
+  // Build score entry
+  const score: Score = {
+    id: generateUUID(),
+    name: name.trim(),
+    wave,
+    faction,
+    difficulty,
+    mode,
+    timestamp: new Date().toISOString(),
+  };
+
+  // Read current leaderboard, insert, sort, trim
+  const scores = await getLeaderboard(env.SCORES);
+  scores.push(score);
+  scores.sort((a, b) => b.wave - a.wave);
+  const trimmed = scores.slice(0, MAX_STORED);
+
+  // Determine rank (1-indexed)
+  const rank = trimmed.findIndex((s) => s.id === score.id) + 1;
+
+  // Write leaderboard and rate-limit key
+  await Promise.all([
+    env.SCORES.put('leaderboard', JSON.stringify(trimmed)),
+    env.SCORES.put(rateKey, Date.now().toString(), { expirationTtl: RATE_LIMIT_SECONDS }),
+  ]);
+
+  if (rank === 0) {
+    // Score was trimmed (didn't make top 500)
+    return json({ success: true, rank: null });
+  }
+
+  return json({ success: true, rank });
+}
+
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    const url = new URL(request.url);
+    const { pathname } = url;
+    const method = request.method.toUpperCase();
+
+    // CORS preflight
+    if (method === 'OPTIONS' && pathname === '/api/scores') {
+      return new Response(null, { status: 204, headers: CORS_HEADERS });
+    }
+
+    if (pathname === '/api/scores') {
+      if (method === 'GET') {
+        return handleGetScores(url, env);
+      }
+      if (method === 'POST') {
+        return handlePostScore(request, env);
+      }
+      return errorResponse('Method not allowed.', 405);
+    }
+
+    return new Response('Not found', { status: 404, headers: CORS_HEADERS });
+  },
+};

--- a/worker/wrangler.toml
+++ b/worker/wrangler.toml
@@ -1,0 +1,7 @@
+name = "td-leaderboard"
+main = "leaderboard.ts"
+compatibility_date = "2024-01-01"
+
+[[kv_namespaces]]
+binding = "SCORES"
+id = "placeholder-fill-in-after-create"


### PR DESCRIPTION
## Custom Maps Polish, Endless Mode, Streamlined Menu & Leaderboard

### Summary
Adds editable map names in the editor, merges Sprint/Standard/Marathon into a unified Standard mode with wave picker, introduces a new Endless mode with infinite scaling, and adds an online leaderboard backed by a Cloudflare Worker.

### Map Editor Polish
- Editable map name field that persists across export/import
- "Copy to Clipboard" button for quick transfer to in-game Custom Maps import

### Endless Mode
- **New game mode**: infinite wave scaling, play until you lose
- Dynamic wave generation in batches of 10, appended when running low
- HP scales cubically beyond wave 50: `20 + wave*10 + wave²*0.5 + max(0, (wave-50))²*0.3`
- Speed caps at 3x, creep count up to 30 per wave
- Boss every 10 waves
- Random creep faction rotation every 10 waves with event log notification
- Never triggers victory — GameOver shows "Survived X waves"
- Skips creep faction select (auto-random since factions rotate)

### Streamlined Menu
- Sprint / Standard / Marathon merged into single **Standard** mode card
- Wave count picker overlay: Quick (15) / Standard (30) / Extended (100)
- New orange **Endless** mode card
- Menu reduced from 8 to 7 mode cards
- `'sprint'` and `'marathon'` removed from `MatchMode` type

### Leaderboard
- **Cloudflare Worker** (`worker/`) with KV-backed score storage
  - `GET /api/scores` — top scores with optional mode/limit filters
  - `POST /api/scores` — submit with validation + 60s IP rate limiting
  - Sorted by wave desc, top 500 retained
- **LeaderboardScene**: scrollable top 50 scores with rank/name/wave/faction/difficulty columns
- **GameOverScene**: "Submit Score" button for Endless mode, prompts for name, shows rank
- Gold **Leaderboard** button in menu between Encyclopedia and Changelog
- API endpoint: `https://signal.streamingsplats.com`
- 