### PR TITLE
Fix custom map import: respect explicit animated cells

### DIFF
--- a/src/data/GauntletMaps.ts
+++ b/src/data/GauntletMaps.ts
@@ -46,13 +46,14 @@ function toPosArray(arr: ([number, number] | Pos)[]): Pos[] {
 }
 
 /** Convert a JSON map to builder result */
-function fromJSON(json: MapJSON): { blocked: Pos[]; noBuild: Pos[]; structures?: LargeStructurePlacement[] } {
+function fromJSON(json: MapJSON): { blocked: Pos[]; noBuild: Pos[]; animated: Pos[]; structures?: LargeStructurePlacement[] } {
+  const animated = toPosArray(json.animated || []);
   const blocked = [
     ...toPosArray(json.blocked),
-    ...toPosArray(json.animated || []),
+    ...animated,
   ];
   const noBuild = toPosArray(json.noBuild);
-  return { blocked, noBuild, structures: json.structures };
+  return { blocked, noBuild, animated, structures: json.structures };
 }
 
 // =====================================================================
@@ -66,7 +67,7 @@ export interface GauntletMapConfig {
   theme: string;
   entries: Pos[];
   exits: Pos[];
-  builder: () => { blocked: Pos[]; noBuild: Pos[]; structures?: LargeStructurePlacement[] };
+  builder: () => { blocked: Pos[]; noBuild: Pos[]; animated?: Pos[]; structures?: LargeStructurePlacement[] };
 }
 
 const MAP_DATA: Record<string, MapJSON> = {
@@ -113,7 +114,7 @@ export const GAUNTLET_MAP_CONFIGS: GauntletMapConfig[] = [
 export function getGauntletMap(faction: FactionId): MapDefinition {
   const config = GAUNTLET_MAP_CONFIGS.find(m => m.faction === faction);
   if (!config) throw new Error(`No gauntlet map for faction: ${faction}`);
-  const { blocked, noBuild, structures } = config.builder();
+  const { blocked, noBuild, animated, structures } = config.builder();
   const mapId = `gauntlet_${config.faction}` as any;
   return {
     id: mapId,
@@ -124,6 +125,7 @@ export function getGauntletMap(faction: FactionId): MapDefinition {
     exits: config.exits,
     blocked,
     noBuild,
+    animated,
     structures,
   };
 }

--- a/src/data/Maps.ts
+++ b/src/data/Maps.ts
@@ -20,6 +20,11 @@ export interface MapDefinition {
   exits: { col: number; row: number }[];
   blocked: { col: number; row: number }[];
   noBuild: { col: number; row: number }[];
+  /** Explicitly-animated blocked cells (crystal pools, lava pits, etc).
+   *  These cells are also included in `blocked` for pathfinding, but this list
+   *  tells TerrainManager to render them as the theme's "animated" terrain
+   *  instead of guessing from cluster shape. */
+  animated?: { col: number; row: number }[];
   /** Terrain theme — determines how blocked cells are rendered.
    *  'generic' is used for random maps (automatic assignment). */
   theme?: string;

--- a/src/scenes/GameScene.ts
+++ b/src/scenes/GameScene.ts
@@ -1503,7 +1503,7 @@ export class GameScene extends Phaser.Scene {
   drawGrid(): void {
     // Use terrain manager for themed rendering
     const themeId = this.mapDef?.theme ?? 'generic';
-    this.terrainMgr.compute(this.grid, themeId, this.mapDef?.structures);
+    this.terrainMgr.compute(this.grid, themeId, this.mapDef?.structures, this.mapDef?.animated);
     this.terrainMgr.render(this.grid, this.gridOffsetY);
   }
 

--- a/src/systems/MapStorage.ts
+++ b/src/systems/MapStorage.ts
@@ -119,9 +119,10 @@ export class MapStorage {
   /** Convert a StoredCustomMap to a MapDefinition usable by GameScene */
   static toMapDefinition(stored: StoredCustomMap): MapDefinition {
     const json = stored.json;
+    const animated = toPosArray(json.animated || []);
     const blocked = [
       ...toPosArray(json.blocked),
-      ...toPosArray(json.animated || []),
+      ...animated,
     ];
     const noBuild = toPosArray(json.noBuild);
     const entries = json.entries.map(e => Array.isArray(e) ? { col: (e as unknown as number[])[0], row: (e as unknown as number[])[1] } : e);
@@ -136,6 +137,7 @@ export class MapStorage {
       exits,
       blocked,
       noBuild,
+      animated,
       structures: json.structures,
     };
   }

--- a/src/systems/TerrainManager.ts
+++ b/src/systems/TerrainManager.ts
@@ -255,7 +255,7 @@ export class TerrainManager {
   }
 
   /** Compute terrain types for all cells based on grid and theme */
-  compute(grid: Grid, themeId: string, structures?: LargeStructurePlacement[]): void {
+  compute(grid: Grid, themeId: string, structures?: LargeStructurePlacement[], animatedCells?: { col: number; row: number }[]): void {
     const theme = THEMES[themeId] ?? THEMES.generic;
     this.groundType = theme.ground;
     this.themeId = themeId;
@@ -267,11 +267,32 @@ export class TerrainManager {
     const rows = grid.rows;
     const cols = getGridCols();
 
+    // Build the explicit animated-cell set. These cells skip cluster heuristics
+    // and are directly assigned the theme's animated terrain type.
+    const animatedSet = new Set<string>();
+    const ft = this.factionTerrain;
+    let animatedTerrain: BlockedTerrainType | null = null;
+    if (ft) {
+      for (const [t, m] of Object.entries(ft.typeMapping)) {
+        if (m === 'animated') { animatedTerrain = t as BlockedTerrainType; break; }
+      }
+    }
+    if (animatedCells && animatedTerrain) {
+      for (const cell of animatedCells) {
+        const key = `${cell.col},${cell.row}`;
+        animatedSet.add(key);
+        this.terrainMap.set(key, animatedTerrain);
+      }
+    }
+
+    // Remaining blocked cells go through cluster detection to guess wall vs pool
     const blockedSet = new Set<string>();
     for (let r = 0; r < rows; r++) {
       for (let c = 0; c < cols; c++) {
         if (grid.cells[r][c] === CellType.Blocked) {
-          blockedSet.add(`${c},${r}`);
+          const key = `${c},${r}`;
+          if (animatedSet.has(key)) continue;
+          blockedSet.add(key);
         }
       }
     }


### PR DESCRIPTION
Editor-authored maps mark crystal pool / lava pit cells in a separate 'animated' list. The JSON loader was merging them into 'blocked', losing that distinction. TerrainManager then guessed terrain type per cluster using a shape heuristic (size >= 8, aspect <= 2 → animated pool), which misfires on any roughly-square wall cluster — e.g. a wizard tower base would render as crystal pool tiles.

Now MapDefinition carries an explicit 'animated' list. TerrainManager directly assigns the theme's animated terrain type to those cells and skips them during cluster detection, so walls stay walls.