### PR TITLE
Refactor: pylon invariant + Tower.ts bag-of-flags v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Changelog
 
+## 2026-05-18
+
+### Tower.ts bag-of-flags refactor (v2)
+
+Two campaigns shipped, two campaigns' worth of mission-specific flags accreted on `Tower.ts`. Each new campaign would have piled on another 5–8 fields. This refactor extracts every mission-specific concern off the base class onto declarative traits, so campaign #3+ adds zero `Tower.ts` lines.
+
+**Design** (in `docs/tower-bag-of-flags-v2-plan.md`): three new pipelines on `Tower` replace hard-coded forks.
+
+1. **Damage pipeline** — `Tower.takeDamage(amount, source?)` flows through `resolveDamageVeto` → `resolveTowerDamageModifiers` → apply → `resolveOnTakeDamage` → `resolveOnKill`. Future shields, % resists, last-stand mechanics hang off these registries as trait handlers. Composable, not boolean.
+2. **Render-hooks registry** — `drawTower` ends with `resolveOverlayDraw(traits, ...)`. Campaign overlays (golden ult border, conduit link arc, future hack/decrypt visuals) register as trait handlers; `drawTower` no longer knows about any specific campaign.
+3. **Trait lifecycle extension** — `Trait.ts` gains `onSpawn` / `onDespawn` / `onTakeDamage` / `onKill` / `onOverlayDraw` registries paralleling the existing `onFire` / `towerUpdate` registries. Purely additive.
+
+**What moved to traits.** Mech finale tags (`mech_generator` carrying `linkedCells`, `mech_throne`, `invulnerable`), suppression state (`suppressible` with `stress` + `seenLastFired`), Arcane finale (`arcane_ult_target`), conduit linking (`conduit_linked` with `srcX` / `srcY`). Controllers stay for orchestration but read traits instead of stamping flags on `Tower`.
+
+**What stayed on `Tower`** (intentional, per the plan): `_disabledRemaining` (generic status, future StatusEffects target), `_expired` / `alive` (lifecycle — used by non-destructible towers too), `_lastAttackedHeroAt` (outbound retaliation, not bag-of-flags). Destructibility grouped into a single `Tower.destructible: DestructibleState | null` sub-object (hp / maxHp / lastHitAt); inbound retaliation onto `Tower.assailants: AssailantLog` (last-hit timestamps by source type, shared with `DestructibleStructure`).
+
+**Three `(this as any)` casts in `drawTower`** that have been embarrassing since they landed are gone — replaced by typed trait state.
+
+**Sequencing.** Seven commits, each self-contained with `npx tsc --noEmit` clean + full unit suite green + M10 e2e green after each. Test count: 626 → 645. The M10 e2e (`e2e/m10-overthrow.spec.ts`) is the integration safety net — asserts on `SabotageController.getSnapshot()` state, not flag shapes, so it caught regressions through the rewrite.
+
+Files: `src/entities/Tower.ts`, `src/entities/Destructibility.ts` (new), `src/entities/Damageable.ts` (lifted from `systems/finale/`), `src/systems/traits/Trait.ts` (+test), `src/systems/sabotage/SabotageTraits.ts` (new), `src/systems/finale/FinaleTraits.ts` (new), `src/systems/traits/TowerTraitHandlers.ts`, `src/systems/sabotage/SabotageController.ts` (+test), `src/systems/suppression/SuppressionManager.ts` (+test), `src/systems/suppression/SuppressionRender.ts`, `src/systems/finale/FinaleController.ts`, `src/systems/finale/cpuPlacement.ts`, `src/entities/DestructibleStructure.ts`, `src/entities/Hero.ts`, `src/scenes/GameScene.ts`, `src/systems/TowerManager.ts`, `src/main.ts`, `src/entities/Tower.takeDamage.test.ts`.
+
+### Suppression pylon-cell invariant
+
+The pylon-on-noBuild assumption (load-bearing for the GameScene click-handler's pylon-channel intercept) moved out of GameScene's inline stamp loop into `SuppressionManager`'s constructor. Auto-converts Empty → NoBuild (preserves old behavior); warns loudly when a pylon sits on Entry/Exit/Blocked/Tower without mutating the cell type (so the bug stays visible in-game). Silently skips out-of-bounds pylons. Five new tests.
+
 ## 2026-05-17
 
 ### Mech M10 Playwright e2e coverage

--- a/docs/tower-bag-of-flags-v2-plan.md
+++ b/docs/tower-bag-of-flags-v2-plan.md
@@ -1,0 +1,106 @@
+# Plan — Tower.ts Bag-of-Flags Refactor v2
+
+**Status:** Active, branch `ah/cleanup/sprite-location-pylon-invariant` → PR #73.
+**Owner:** Alex
+**Trigger:** Two campaigns (Arcane, Mech) shipped; each added 5–10 mission-specific fields directly to `Tower.ts`. A third campaign before the refactor repeats the same debt pattern at higher migration cost.
+
+---
+
+## The disease
+
+`Tower.ts` currently carries clusters of mission-specific state directly on the base class:
+
+| Cluster | Fields | Source |
+|---|---|---|
+| Destructibility (M10/finale) | `destructible`, `hp`, `maxHp`, `_lastHitAt`, `_expired`, `alive` getter | Arcane/Mech M10 |
+| Hero/send retaliation | `_lastHeroHitAt`, `_lastSendHitAt`, `_lastAttackedHeroAt` | Arcane finale |
+| Mech finale tags | `_invulnerable`, `isGenerator`, `_generatorDrained`, `generatorLinkedCells`, `isThrone` | Mech M10 |
+| Mech suppression | `_stress`, `_suppressionSeenLastFired` | Mech campaign |
+| Arcane finale | `isUlt` | Arcane M10 |
+| Stormcaller stun | `_disabledRemaining` | Stormcaller channel |
+| Aura cosmetics (`as any` casts!) | `_linkedByConduit`, `_conduitX`, `_conduitY` | Conduit aura tower |
+
+Every new campaign adds another 5–8 fields. Three `(this as any)` casts in `drawTower` are already embarrassing. After three campaigns the class is unmaintainable.
+
+## Why this plan (v2) replaced v1
+
+v1 (per-controller WeakMaps for mission tags) was reviewed and rejected for three forecast failures across "many future campaign one-offs":
+
+1. **`_damageVeto: boolean` doesn't compose.** Future campaigns want shields, % resists, last-stand, mute windows. A single boolean re-becomes a bag of booleans by campaign #4.
+2. **`drawTower` becomes the new bag-of-flags.** Moving state off `Tower` left rendering branches on `Tower`. Each new campaign visual lands another conditional in `drawTower` plus a controller import in the base class.
+3. **WeakMap fragmentation.** N campaigns → N controllers → N WeakMaps. Discovering "what state does tower X have" means grepping across all controllers. Exactly the discoverability problem we're trying to fix.
+
+v2 fixes all three: state co-located on the tower (as trait instances), declarative in data files, `drawTower` iterates a registry, zero `Tower.ts` edits per campaign.
+
+## Architecture
+
+Three pipelines on `Tower`, none of them hard-coded:
+
+### 1. Damage pipeline
+
+Replaces hard-coded forks in `Tower.takeDamage`:
+
+```
+takeDamage(amount, source?) →
+  resolveDamageVeto(traits, amount, source)    // OR semantics: any veto wins
+  resolveDamageModifiers(traits, amount, source) // chain: modifier (amount, ctx) → amount
+  apply hp damage                              // hp -= final, log assailant, _lastHitAt
+  resolveOnKill(traits, source)                // on hp ≤ 0
+```
+
+Future shields, % resists, last-stand, mute windows all become trait handlers. Composable, not boolean.
+
+### 2. Render-hooks registry
+
+`drawTower` calls base render + iterates `resolveOverlayDraw(traits, tower, graphics, scene)`. Sabotage / Suppression / Finale modules register their own overlays at module-init time; `drawTower` stops knowing about any campaign.
+
+### 3. Trait lifecycle extension
+
+`Trait.ts` gains `onSpawn`, `onDespawn`, `onTakeDamage`, `onKill`, `onOverlayDraw` registries paralleling the existing `onFire` / `towerUpdate` / etc. Purely additive — no existing handler changes.
+
+## What lives where
+
+**Destructibility stays on `Tower`** (as `Tower.destructible: DestructibleState | null` sub-object). Parity with `DestructibleStructure` via `Damageable` matters; ~25 reader sites is bounded migration cost.
+
+**Mission tags become traits**: `mech_generator` (carries `linkedCells`), `mech_throne`, `mech_invulnerable_until_generators_dead`, `arcane_ult_target` — declarative in tower data, discoverable via `getTrait(tower.traits, 'id')`. **Zero new `Tower.ts` fields per campaign.**
+
+**Controllers stay**, but for orchestration only (timelines, win-checks, cross-tower coordination). They *read* traits; they don't stamp WeakMaps.
+
+**Stormcaller stun stays** as a single field — generic status, future `StatusEffects` system absorbs it.
+
+## The 7-commit shape
+
+Each commit is a self-contained migration with its own tests. Full unit suite + `e2e/m10-overthrow.spec.ts` must stay green after each.
+
+1. **Lift `Damageable` out of `systems/finale/`** to `src/entities/Damageable.ts`. Add `assailants: AssailantLog` (last-hit timestamps by source type). Pure rename + extension.
+2. **Extend Trait pipeline** with `onSpawn` / `onDespawn` / `onTakeDamage` / `registerDamageVeto` / `registerDamageModifier` / `registerOnKill` / `registerOverlayDraw` registries + resolvers. Pure addition.
+3. **Damage pipeline + `Tower.destructible` sub-object.** Group `hp`, `maxHp`, `_lastHitAt` into one struct. Retaliation triplet moves onto `Damageable.assailants` (shared with `DestructibleStructure`). `Tower` formally `implements Damageable`. Migrate ~25 reader sites.
+4. **Mech finale tags → traits.** `mech_generator` (with `linkedCells`), `mech_throne`, `mech_invulnerable_until_generators_dead` (registers a damage-veto handler that queries `SabotageController.allGeneratorsDead()`). Drop `_invulnerable`, `isGenerator`, `_generatorDrained`, `generatorLinkedCells`, `isThrone` from `Tower`.
+5. **Suppression `_stress` → trait.** Per-tower stress lives on a `suppressible` trait. `SuppressionManager.test.ts` updated to read trait state.
+6. **Arcane `isUlt` → trait + render hook.** `arcane_ult_target` trait registers the golden HP-bar overlay drawer. `drawTower` ends with one call to `resolveOverlayDraw`.
+7. **Conduit cosmetics → trait state.** Aura-side `_linkedByConduit` becomes trait state populated each frame by the conduit handler. Removes the three `(this as any)` casts in `drawTower`.
+
+## Out of scope
+
+- `_disabledRemaining` (Stormcaller stun) — stays as-is. Generic status. Lift to a future `StatusEffects` system when a second consumer appears.
+- `_expired` / `alive` getter — stays on `Tower` (lifecycle, used by non-destructible mobile towers too).
+- Existing trait handlers (delivery, damage modifiers for hits, fire rate, etc.) — untouched. We're only *adding* registries.
+
+## Risks documented
+
+1. **Trait pipeline ordering for damage veto** — OR semantics (any-true vetoes) is the obvious choice; documents need to say so.
+2. **Damage source enum** — typed `'hero' | 'send' | 'creep' | 'tower' | 'unknown'`, not string. Catches typos at compile time.
+3. **Overlay draw order** between conduit link + ult border — probably irrelevant (Phaser graphics composites), but worth confirming with both registered.
+4. **Test data ergonomics** — `traits: [{id: 'mech_generator', ...}]` inline in tests must read cleaner than the current `isGenerator: true` literal. If it doesn't, that's a signal to revisit.
+5. **Controller invulnerability query** — `mech_invulnerable_until_generators_dead`'s damage-veto handler needs a cheap synchronous `SabotageController.allGeneratorsDead()` read. Probably already a counter, not iteration; verify.
+6. **Backwards-compat during migration** — each commit must leave the game playable; we don't allow a half-state where mech M10 is broken because some readers haven't migrated yet.
+
+## Safety nets
+
+- Full unit suite (631 tests) plus the new `SabotageController` / `SuppressionManager` / `Tower.takeDamage` coverage exercises both Mech and Arcane finale paths.
+- `e2e/m10-overthrow.spec.ts` is the integration safety net — asserts on `SabotageController.getSnapshot()` state, not on flag shapes, so it survives the rewrite and catches regressions through it.
+- Each commit's acceptance gate: `npx tsc --noEmit` clean + full unit suite green + M10 e2e green.
+
+## Effort estimate
+
+7 commits, ~6–8 hrs over 2 sessions. Each commit is a tight diff with focused tests.

--- a/src/entities/Damageable.ts
+++ b/src/entities/Damageable.ts
@@ -1,8 +1,8 @@
 /**
  * Damageable — unified interface for things the M10 finale's hero
  * (and queued sends) can attack. Implemented by `Tower` (when its
- * `destructible` flag is true) and `DestructibleStructure` (the new
- * PRD 06 entity for multi-tile boss structures).
+ * `destructible` sub-object is non-null) and `DestructibleStructure`
+ * (the PRD 06 entity for multi-tile boss structures).
  *
  * The hero's `findTarget<T extends Damageable>` and the send-creep
  * "attack adjacent CPU destructible" pathway both consume this
@@ -12,7 +12,40 @@
  * answer): exposes footprint dims, faction ownership, and the
  * mission-win-target flag so callers can prioritize / filter without
  * casting back to the concrete type.
+ *
+ * Lives in `entities/` (not `systems/finale/`) — campaign-agnostic
+ * primitive. Hero attacks, send attacks, raider attacks, future
+ * destructible mechanics all route through this contract.
  */
+
+/** Where damage came from. Drives retaliation priority on the
+ *  receiving entity (e.g. a CPU tower whose hero hit it recently
+ *  retaliates against the hero before falling back to range-based
+ *  targeting). Typed so a typo at a call site fails at compile time
+ *  instead of silently falling into `'unknown'`. */
+export type DamageSource = 'hero' | 'send' | 'creep' | 'tower' | 'raider' | 'unknown';
+
+/** Per-source last-hit timestamps (scene time ms). Lookups use the
+ *  `lastBy` accessor; writes use `log`. -Infinity marks "never hit by
+ *  this source." Held by every Damageable so retaliation logic works
+ *  uniformly for Tower and DestructibleStructure (and any future
+ *  destructible entity). */
+export interface AssailantLog {
+  log(source: DamageSource, now: number): void;
+  lastBy(source: DamageSource): number;
+}
+
+/** Default factory — flat in-memory record. Cheap; one allocation per
+ *  destructible entity. Per-source state stays public via the getter
+ *  so the implementation can switch to a Map / Int32Array later if
+ *  the per-frame retaliation lookup ever becomes a hot path. */
+export function createAssailantLog(): AssailantLog {
+  const last: Partial<Record<DamageSource, number>> = {};
+  return {
+    log(source, now) { last[source] = now; },
+    lastBy(source) { return last[source] ?? -Infinity; },
+  };
+}
 
 /** Generic damage target. Tower and DestructibleStructure both
  *  implement this. */
@@ -51,13 +84,23 @@ export interface Damageable {
   /** When true, FinaleController.checkWin() requires this target to
    *  be dead before firing onWin. */
   readonly isMissionWinTarget: boolean;
+  /** Per-source last-hit log. Lets retaliation logic ("X is attacking
+   *  me — fire back at X first") work uniformly across destructible
+   *  entity kinds. Optional for back-compat with Damageable
+   *  implementations that haven't migrated yet; remove the `?` after
+   *  all implementers carry one. */
+  readonly assailants?: AssailantLog;
 
   /**
    * Apply damage. Returns true on the killing blow (HP just hit 0),
    * false otherwise. Implementations are responsible for marking
    * themselves expired — callers should NOT mutate hp directly.
+   *
+   * `source` lets the receiving entity log who hit it (for retaliation
+   * priority). Optional for back-compat; defaults to 'unknown' inside
+   * implementations that read it.
    */
-  takeDamage(amount: number): boolean;
+  takeDamage(amount: number, source?: DamageSource): boolean;
 }
 
 /** Cheap "is this a Damageable?" runtime check — lets handlers safely

--- a/src/entities/Destructibility.ts
+++ b/src/entities/Destructibility.ts
@@ -1,0 +1,34 @@
+/**
+ * DestructibleState — grouped destructibility cluster, replacing the
+ * scattered `hp?` / `maxHp?` / `_lastHitAt` fields on Tower. Null when
+ * the tower is invincible (every player tower in every existing
+ * mission); non-null only on M10/finale CPU defender towers that the
+ * hero / sends can attack.
+ *
+ * Lives in entities/ rather than systems/ because it's a per-entity
+ * data cluster — no behavior, no global state. Construction goes
+ * through `createDestructibleState` for default-aware initialization.
+ *
+ * Retaliation timestamps (who hit me, when) live on AssailantLog from
+ * Damageable.ts rather than here — that lets DestructibleStructure
+ * carry retaliation too without duplicating fields.
+ */
+
+export interface DestructibleState {
+  hp: number;
+  readonly maxHp: number;
+  /** Scene time (ms) of the most recent damage applied. Drives the
+   *  brief white-flash on the sprite in drawTower. -Infinity = never
+   *  hit. */
+  lastHitAt: number;
+}
+
+/** Factory. `hp` defaults to `maxHp` for fresh placements; pass
+ *  explicitly when resuming from a saved state. */
+export function createDestructibleState(maxHp: number, hp?: number): DestructibleState {
+  return {
+    hp: hp ?? maxHp,
+    maxHp,
+    lastHitAt: -Infinity,
+  };
+}

--- a/src/entities/DestructibleStructure.ts
+++ b/src/entities/DestructibleStructure.ts
@@ -21,6 +21,7 @@ import { TILE_SIZE, gridX, gridY, gridLeftX } from '../config';
 import { Tower } from './Tower';
 import { DestructibleStructureDef, DestructibleStructurePlacement, getDestructibleStructureDef } from '../data/DestructibleStructures';
 import { Damageable } from './Damageable';
+import { createDestructibleState } from './Destructibility';
 import { destructibleStructureFrame } from '../systems/ArenaFloorRenderer';
 
 export class DestructibleStructure implements Damageable {
@@ -110,10 +111,8 @@ export class DestructibleStructure implements Damageable {
     // If we have an embedded tower, mirror our HP onto it so all the
     // existing hp/maxHp/destructible code paths Just Work.
     if (this.embeddedTower) {
-      this.embeddedTower.destructible = true;
+      this.embeddedTower.destructible = createDestructibleState(this.maxHp);
       this.embeddedTower.ownerIndex = args.ownerIndex;
-      this.embeddedTower.maxHp = this.maxHp;
-      this.embeddedTower.hp = this.maxHp;
       // Mark the tower as a structure-attached attacker so other
       // systems can recognise the relationship if needed.
       (this.embeddedTower as { _structureRef?: DestructibleStructure })._structureRef = this;
@@ -165,19 +164,20 @@ export class DestructibleStructure implements Damageable {
   // ── Damageable conformance ────────────────────────────────────
 
   get hp(): number {
-    if (this.embeddedTower) return this.embeddedTower.hp ?? 0;
+    if (this.embeddedTower) return this.embeddedTower.destructible?.hp ?? 0;
     return this.standaloneHp;
   }
   set hp(v: number) {
-    if (this.embeddedTower) this.embeddedTower.hp = v;
-    else this.standaloneHp = v;
+    if (this.embeddedTower) {
+      if (this.embeddedTower.destructible) this.embeddedTower.destructible.hp = v;
+    } else this.standaloneHp = v;
   }
 
   get alive(): boolean {
     if (this._expired) return false;
     if (this.embeddedTower) {
       const exp = (this.embeddedTower as { _expired?: boolean })._expired;
-      return !exp && (this.embeddedTower.hp ?? 0) > 0;
+      return !exp && (this.embeddedTower.destructible?.hp ?? 0) > 0;
     }
     return this.standaloneHp > 0;
   }

--- a/src/entities/DestructibleStructure.ts
+++ b/src/entities/DestructibleStructure.ts
@@ -20,7 +20,7 @@ import * as Phaser from 'phaser';
 import { TILE_SIZE, gridX, gridY, gridLeftX } from '../config';
 import { Tower } from './Tower';
 import { DestructibleStructureDef, DestructibleStructurePlacement, getDestructibleStructureDef } from '../data/DestructibleStructures';
-import { Damageable } from '../systems/finale/Damageable';
+import { Damageable } from './Damageable';
 import { destructibleStructureFrame } from '../systems/ArenaFloorRenderer';
 
 export class DestructibleStructure implements Damageable {

--- a/src/entities/Hero.ts
+++ b/src/entities/Hero.ts
@@ -631,13 +631,20 @@ export class Hero {
     });
     // Mark the target as "recently hit by hero" so its target-priority
     // logic can retaliate: a tower that's been shot by the hero
-    // re-targets the hero before considering creeps in range.
-    if ('_lastHeroHitAt' in target) {
-      (target as { _lastHeroHitAt: number })._lastHeroHitAt = this.scene.time.now;
-    } else if ('embeddedTower' in target && target.embeddedTower) {
-      target.embeddedTower._lastHeroHitAt = this.scene.time.now;
+    // re-targets the hero before considering creeps in range. The
+    // hit log lives on AssailantLog under the unified Damageable
+    // contract; the takeDamage call below also writes the timestamp,
+    // but doing it up-front lets the embedded-tower case (where the
+    // hero may be hitting a structure that delegates to its tower)
+    // get the log too.
+    const assailants = (target as { assailants?: { log: (s: string, n: number) => void } }).assailants;
+    if (assailants) {
+      assailants.log('hero', this.scene.time.now);
+    } else {
+      const embedded = (target as { embeddedTower?: Tower }).embeddedTower;
+      if (embedded) embedded.assailants.log('hero', this.scene.time.now);
     }
-    const killed = target.takeDamage(dmg);
+    const killed = target.takeDamage(dmg, 'hero');
     if (killed) {
       this.towersDestroyed++;
       this.clickedTarget = null; // clear so player can pick a new one
@@ -1359,5 +1366,5 @@ function isClickedTargetAlive(t: Tower | DestructibleStructure): boolean {
   const tw = t as Tower;
   if (!tw.destructible) return false;
   if ((tw as { _expired?: boolean })._expired) return false;
-  return (tw.hp ?? 1) > 0;
+  return tw.destructible.hp > 0;
 }

--- a/src/entities/Tower.takeDamage.test.ts
+++ b/src/entities/Tower.takeDamage.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import { Tower } from './Tower';
 import { HeadlessScene } from '../headless/HeadlessScene';
 import { getTowerType } from '../data/TowerTypes';
+import { createDestructibleState } from './Destructibility';
 
 function makeTower(): Tower {
   const scene = new HeadlessScene();
@@ -9,42 +10,36 @@ function makeTower(): Tower {
 }
 
 describe('Tower.takeDamage (M10 finale destructibility)', () => {
-  it('no-ops when destructible flag is not set (default for every existing mission)', () => {
+  it('no-ops when destructible is null (default for every existing mission)', () => {
     const t = makeTower();
     const killed = t.takeDamage(100);
     expect(killed).toBe(false);
-    expect(t.hp).toBeUndefined(); // never assigned
+    expect(t.destructible).toBeNull();
     expect((t as { _expired?: boolean })._expired).toBeFalsy();
   });
 
   it('reduces hp on a destructible tower and does not set _expired above 0', () => {
     const t = makeTower();
-    t.destructible = true;
-    t.maxHp = 200;
-    t.hp = 200;
+    t.destructible = createDestructibleState(200);
     const killed = t.takeDamage(50);
     expect(killed).toBe(false);
-    expect(t.hp).toBe(150);
+    expect(t.destructible.hp).toBe(150);
     expect((t as { _expired?: boolean })._expired).toBeFalsy();
   });
 
   it('returns true and sets _expired exactly on the killing blow', () => {
     const t = makeTower();
-    t.destructible = true;
-    t.maxHp = 100;
-    t.hp = 100;
+    t.destructible = createDestructibleState(100);
     expect(t.takeDamage(30)).toBe(false);
     expect(t.takeDamage(30)).toBe(false);
     expect(t.takeDamage(50)).toBe(true); // overkill
-    expect(t.hp).toBe(0);
+    expect(t.destructible.hp).toBe(0);
     expect((t as { _expired?: boolean })._expired).toBe(true);
   });
 
   it('does not double-fire the killing blow (subsequent calls return false)', () => {
     const t = makeTower();
-    t.destructible = true;
-    t.maxHp = 50;
-    t.hp = 50;
+    t.destructible = createDestructibleState(50);
     expect(t.takeDamage(60)).toBe(true);
     expect(t.takeDamage(10)).toBe(false); // already dead
     expect(t.takeDamage(10)).toBe(false);
@@ -52,10 +47,26 @@ describe('Tower.takeDamage (M10 finale destructibility)', () => {
 
   it('clamps hp to 0 instead of going negative', () => {
     const t = makeTower();
-    t.destructible = true;
-    t.maxHp = 30;
-    t.hp = 30;
+    t.destructible = createDestructibleState(30);
     t.takeDamage(999);
-    expect(t.hp).toBe(0);
+    expect(t.destructible.hp).toBe(0);
+  });
+
+  it('logs the assailant timestamp by source', () => {
+    const t = makeTower();
+    t.destructible = createDestructibleState(200);
+    // Headless scene's time.now is 0 by default; sufficient to assert
+    // the source was logged (was -Infinity before any hit).
+    expect(t.assailants.lastBy('hero')).toBe(-Infinity);
+    t.takeDamage(10, 'hero');
+    expect(t.assailants.lastBy('hero')).toBeGreaterThan(-Infinity);
+    expect(t.assailants.lastBy('send')).toBe(-Infinity);
+  });
+
+  it('defaults the damage source to "unknown" when omitted', () => {
+    const t = makeTower();
+    t.destructible = createDestructibleState(200);
+    t.takeDamage(5);
+    expect(t.assailants.lastBy('unknown')).toBeGreaterThan(-Infinity);
   });
 });

--- a/src/entities/Tower.ts
+++ b/src/entities/Tower.ts
@@ -153,11 +153,6 @@ export class Tower {
    *  prior tick" without a fire event. -Infinity = never observed. */
   _suppressionSeenLastFired: number = -Infinity;
 
-  /** Mech finale: throne (Voss) is invulnerable until every generator
-   *  on the map has been destroyed. SabotageController flips this to
-   *  false once that's true. takeDamage() short-circuits while set. */
-  _invulnerable: boolean = false;
-
   /** Lifecycle marker. Set true by `takeDamage()` on the killing blow
    *  (or by mission controllers when an entity is consumed without HP
    *  damage, e.g. a generator's linked towers powering down). The
@@ -171,26 +166,6 @@ export class Tower {
    *  when scanning CPU towers for auto-targeting. Lets the duck-type
    *  resolve without `as unknown as` casts at the call sites. */
   get alive(): boolean { return !this._expired; }
-
-  /** Mech finale: cells of CPU towers this generator powers. When the
-   *  generator dies, SabotageController kills every linked tower
-   *  (sets _expired = true, no rewards). Empty for non-generator
-   *  towers. Only meaningful when `destructible` is also true. */
-  generatorLinkedCells?: { col: number; row: number }[];
-
-  /** Mech finale: tags this tower as a generator so the controller
-   *  knows to drop its `generatorLinkedCells` on death. */
-  isGenerator?: boolean;
-
-  /** Mech finale: SabotageController bookkeeping — set true once the
-   *  controller has drained this generator's linked towers. Prevents
-   *  the cascade firing twice if update() runs after the dead frame. */
-  _generatorDrained?: boolean;
-
-  /** Mech finale: tags this tower as the master throne (Voss). The
-   *  throne is the win-condition target — destroying it ends the
-   *  mission. While any generator is alive, _invulnerable is true. */
-  isThrone?: boolean;
 
   /** M10 finale: tower destructibility. Null = invincible (every
    *  player tower in every existing mission). Non-null only on M10

--- a/src/entities/Tower.ts
+++ b/src/entities/Tower.ts
@@ -140,19 +140,6 @@ export class Tower {
    *  while > 0, fire logic is skipped and a stunned overlay draws. */
   _disabledRemaining: number = 0;
 
-  /** Mechanical campaign: Voss's Suppression Pylons disrupt arcane
-   *  channels. SuppressionManager polls `lastFired` and bumps this
-   *  counter whenever a tower in an active pylon's radius fires.
-   *  At threshold (default 5) the tower stalls (writes
-   *  `_disabledRemaining`) and stress resets to 0. Untouched
-   *  outside Mech-campaign missions. */
-  _stress: number = 0;
-
-  /** SuppressionManager bookkeeping — last `lastFired` value the
-   *  manager observed. Lets it detect "this tower fired since the
-   *  prior tick" without a fire event. -Infinity = never observed. */
-  _suppressionSeenLastFired: number = -Infinity;
-
   /** Lifecycle marker. Set true by `takeDamage()` on the killing blow
    *  (or by mission controllers when an entity is consumed without HP
    *  damage, e.g. a generator's linked towers powering down). The

--- a/src/entities/Tower.ts
+++ b/src/entities/Tower.ts
@@ -4,6 +4,9 @@ import { TowerType, TowerUpgrade, TOWER_TYPES, TargetingMode } from '../data/Tow
 import { DamageType } from '../data/CreepTypes';
 import { HitTarget } from '../systems/traits/Trait';
 import { hasTowerSprite, isMobileTowerSprite, shouldTowerRotate, createTowerSprite, setTowerSpriteState, updateMobileTowerSprite, hasProjectileSprite, createProjectileSprite, playProjectileImpact } from '../systems/SpriteManager';
+import { type DestructibleState, createDestructibleState } from './Destructibility';
+import { type AssailantLog, createAssailantLog, type DamageSource } from './Damageable';
+import { resolveDamageVeto, resolveTowerDamageModifiers, resolveOnTakeDamage, resolveOnKill } from '../systems/traits/Trait';
 
 /** One upgrade option presented to the player. A linear tower has
  *  a single option (branchId=null). A branching tower surfaces the
@@ -189,37 +192,36 @@ export class Tower {
    *  mission. While any generator is alive, _invulnerable is true. */
   isThrone?: boolean;
 
-  /** M10 finale: tower destructibility. Default undefined = invincible
-   *  (every existing mission). Set true on M10 CPU defender towers via
-   *  the `destructibleTowers` map field; the hero attacks them and they
-   *  die when hp hits 0. Player towers (mana drains) stay invincible. */
-  destructible?: boolean;
-  hp?: number;
-  maxHp?: number;
-  /** PRD 06 / M10 v2 — last time the hero damaged this tower (scene
-   *  time ms). Drives "X is attacking me" target priority: a CPU
-   *  tower that's been hit by the hero recently retaliates against
-   *  the hero before falling back to range-based picking. */
-  _lastHeroHitAt: number = 0;
-  /** Last time a SEND creep damaged this tower (scene time ms).
-   *  Same retaliation rule as _lastHeroHitAt but for sends. */
-  _lastSendHitAt: number = 0;
-  /** Last time this tower fired at the hero (scene time ms). The
-   *  hero's auto-attack priority bumps "towers that have been
-   *  shooting me" to the top of the cascade — retaliation reads
-   *  natural for the player. */
+  /** M10 finale: tower destructibility. Null = invincible (every
+   *  player tower in every existing mission). Non-null only on M10
+   *  CPU defender towers; the hero attacks them and they die when
+   *  hp hits 0. Set via `setDestructible(maxHp)` at placement.
+   *
+   *  Holds hp / maxHp / lastHitAt — used to be three separate optional
+   *  fields. Grouping reduces "is this destructible?" branching and
+   *  lets Tower formally satisfy the Damageable interface once a
+   *  later commit adds the remaining read-only conformance fields. */
+  destructible: DestructibleState | null = null;
+  /** Per-source last-hit timestamps (hero / send / creep / tower /
+   *  raider). Replaces the scattered `_lastHeroHitAt` / `_lastSendHitAt`
+   *  pair (incoming damage log). Always present; on non-destructible
+   *  towers it's just unused. */
+  readonly assailants: AssailantLog = createAssailantLog();
+  /** Outbound retaliation tracker — when this tower last *fired at*
+   *  the hero (scene time ms). The hero's auto-attack priority bumps
+   *  "towers that have been shooting me" to the top of the cascade
+   *  so retaliation reads natural for the player. Distinct from the
+   *  inbound `assailants` log: this is "I attacked X" not "X attacked
+   *  me," so it stays as its own field rather than flipping into
+   *  AssailantLog. */
   _lastAttackedHeroAt: number = 0;
   /** Whether this tower is a "boss-tier" CPU defender. Drives the
    *  golden HP-bar border treatment in the renderer. PRD 06 migrated
    *  the M10 throne off this flag onto a `DestructibleStructure` with
    *  `isMissionWinTarget`; the field stays here for any future
    *  campaigns that want a single-cell bossy tower without a 3×3
-   *  structure. Phase mechanics now live on `DestructibleStructure.phaseHooks`
-   *  + `FinaleEffects` rather than Tower flags. */
+   *  structure. (Will move to `arcane_ult_target` trait in commit 6.) */
   isUlt?: boolean;
-  /** Last time the tower took damage (scene.time.now). Drives a brief
-   *  white-flash on the sprite. */
-  _lastHitAt: number = 0;
 
   constructor(scene: Phaser.Scene, col: number, row: number, towerType: TowerType) {
     this.col = col;
@@ -386,12 +388,12 @@ export class Tower {
       this.graphics.strokeCircle(this.x, this.y, this.range);
     }
 
-    // M10 finale: HP bar above destructible CPU towers. Default
-    // undefined for every other mission so this is a free no-op.
-    // Hidden at full HP — only shows when the tower's been hit, so
-    // the unhit lattice doesn't read as visually noisy.
-    if (this.destructible && this.maxHp !== undefined && this.hp !== undefined && this.maxHp > 0 && this.hp < this.maxHp) {
-      const ratio = Math.max(0, Math.min(1, this.hp / this.maxHp));
+    // M10 finale: HP bar above destructible CPU towers. Null for
+    // every player tower in every existing mission so this is a
+    // free no-op. Hidden at full HP — only shows when the tower's
+    // been hit, so the unhit lattice doesn't read as visually noisy.
+    if (this.destructible && this.destructible.maxHp > 0 && this.destructible.hp < this.destructible.maxHp) {
+      const ratio = Math.max(0, Math.min(1, this.destructible.hp / this.destructible.maxHp));
       const w = TILE_SIZE * 0.8;
       const h = 3;
       const x = this.x - w / 2;
@@ -404,19 +406,20 @@ export class Tower {
       this.graphics.fillStyle(fillColor, 1);
       this.graphics.fillRect(x, y, w * ratio, h);
       // Ult tower gets a special golden border so the player knows
-      // which one is the win-target.
+      // which one is the win-target. (Will move to arcane_ult_target
+      // overlay-draw handler in commit 6.)
       if (this.isUlt) {
         this.graphics.lineStyle(1, 0xffdd44, 1);
         this.graphics.strokeRect(x, y, w, h);
       }
     }
 
-    // White-flash on damage (50ms after _lastHitAt). Cheap visual cue
+    // White-flash on damage (~80ms after lastHitAt). Cheap visual cue
     // that the tower is being attacked. Sprite tint reverts the next
     // frame because drawTower runs every tick.
-    if (this.destructible && this.sprite && this._lastHitAt > 0) {
+    if (this.destructible && this.sprite && this.destructible.lastHitAt > -Infinity) {
       const now = (this._scene as { time?: { now: number } }).time?.now ?? 0;
-      if (now - this._lastHitAt < 80) {
+      if (now - this.destructible.lastHitAt < 80) {
         // setTintFill replaces sprite color (vs setTint which multiplies);
         // headless stub doesn't accept args reliably so guard.
         const s = this.sprite as { setTintFill?: (c: number) => void };
@@ -429,28 +432,43 @@ export class Tower {
     return this._remainingUpgrades.length > 0;
   }
 
-  /** M10 finale: apply damage. No-op on non-destructible towers (the
-   *  vast majority — every player tower in every existing mission).
-   *  Returns true on the killing blow so the caller (Hero) can grant
-   *  rewards exactly once. _lastHitAt is set so drawTower can render
-   *  a brief white-flash on the sprite. */
-  takeDamage(amount: number): boolean {
-    if (!this.destructible || this.hp === undefined) return false;
-    if (this.hp <= 0) return false; // already dead this frame
-    // Mech finale: throne tower is invulnerable until every generator
-    // is down. SabotageController flips this to false once the last
-    // generator dies; before then, even direct hits are no-op (the
-    // hit is silent, not deflected — the spec says invulnerable, the
-    // VFX layer can render "shield held" if it wants).
-    if (this._invulnerable) return false;
-    this.hp -= amount;
-    this._lastHitAt = (this._scene as { time?: { now: number } }).time?.now ?? 0;
-    if (this.hp <= 0) {
-      this.hp = 0;
+  /** Apply damage through the v2 damage pipeline:
+   *
+   *    veto → modifier chain → apply → onTakeDamage → onKill
+   *
+   *  - Veto runs first (OR semantics; any trait returning true vetoes
+   *    the entire damage event). M10 throne's "invulnerable while
+   *    generators alive" gate lives here as a trait handler (commit 4).
+   *  - Modifier chain transforms the amount (resists, shields, etc.).
+   *  - apply: hp -= final, log assailant, lastHitAt updated.
+   *  - onKill fires once when hp hits 0; the caller (Hero / sends)
+   *    reads the return value to grant rewards exactly once.
+   *
+   *  Non-destructible towers (every player tower in every existing
+   *  mission) short-circuit — no traits run, no hp change. The vast
+   *  majority of calls land here. */
+  takeDamage(amount: number, source: DamageSource = 'unknown'): boolean {
+    if (!this.destructible) return false;
+    const d = this.destructible;
+    if (d.hp <= 0) return false; // already dead this frame
+    if (resolveDamageVeto(this.traits, amount, source, this)) return false;
+    const final = resolveTowerDamageModifiers(this.traits, amount, source, this);
+    if (final <= 0) {
+      resolveOnTakeDamage(this.traits, 0, source, this);
+      return false;
+    }
+    d.hp -= final;
+    const now = (this._scene as { time?: { now: number } }).time?.now ?? 0;
+    d.lastHitAt = now;
+    this.assailants.log(source, now);
+    resolveOnTakeDamage(this.traits, final, source, this);
+    if (d.hp <= 0) {
+      d.hp = 0;
       // Mark for cleanup. TowerManager.cleanupExpired() picks this up
       // next frame and removes the tower from the grid + sprite +
       // recalculates paths (handled in cleanupExpired for destructibles).
       this._expired = true;
+      resolveOnKill(this.traits, source, this);
       return true;
     }
     return false;

--- a/src/entities/Tower.ts
+++ b/src/entities/Tower.ts
@@ -6,7 +6,7 @@ import { HitTarget } from '../systems/traits/Trait';
 import { hasTowerSprite, isMobileTowerSprite, shouldTowerRotate, createTowerSprite, setTowerSpriteState, updateMobileTowerSprite, hasProjectileSprite, createProjectileSprite, playProjectileImpact } from '../systems/SpriteManager';
 import { type DestructibleState, createDestructibleState } from './Destructibility';
 import { type AssailantLog, createAssailantLog, type DamageSource } from './Damageable';
-import { resolveDamageVeto, resolveTowerDamageModifiers, resolveOnTakeDamage, resolveOnKill } from '../systems/traits/Trait';
+import { resolveDamageVeto, resolveTowerDamageModifiers, resolveOnTakeDamage, resolveOnKill, resolveOverlayDraw } from '../systems/traits/Trait';
 
 /** One upgrade option presented to the player. A linear tower has
  *  a single option (branchId=null). A branching tower surfaces the
@@ -177,14 +177,6 @@ export class Tower {
    *  me," so it stays as its own field rather than flipping into
    *  AssailantLog. */
   _lastAttackedHeroAt: number = 0;
-  /** Whether this tower is a "boss-tier" CPU defender. Drives the
-   *  golden HP-bar border treatment in the renderer. PRD 06 migrated
-   *  the M10 throne off this flag onto a `DestructibleStructure` with
-   *  `isMissionWinTarget`; the field stays here for any future
-   *  campaigns that want a single-cell bossy tower without a 3×3
-   *  structure. (Will move to `arcane_ult_target` trait in commit 6.) */
-  isUlt?: boolean;
-
   constructor(scene: Phaser.Scene, col: number, row: number, towerType: TowerType) {
     this.col = col;
     this.row = row;
@@ -367,13 +359,6 @@ export class Tower {
       const fillColor = ratio > 0.5 ? 0x44ff44 : ratio > 0.25 ? 0xffaa00 : 0xff2222;
       this.graphics.fillStyle(fillColor, 1);
       this.graphics.fillRect(x, y, w * ratio, h);
-      // Ult tower gets a special golden border so the player knows
-      // which one is the win-target. (Will move to arcane_ult_target
-      // overlay-draw handler in commit 6.)
-      if (this.isUlt) {
-        this.graphics.lineStyle(1, 0xffdd44, 1);
-        this.graphics.strokeRect(x, y, w, h);
-      }
     }
 
     // White-flash on damage (~80ms after lastHitAt). Cheap visual cue
@@ -388,6 +373,13 @@ export class Tower {
         if (typeof s.setTintFill === 'function') s.setTintFill(0xffffff);
       }
     }
+
+    // v2 overlay-draw pipeline: each trait that registered an
+    // overlay-draw handler paints on top of the base render. Examples:
+    // arcane_ult_target (golden HP-bar border), conduit-link arc.
+    // Replaces what used to be hard-coded `if (this.isUlt) ...`
+    // branches in this function.
+    resolveOverlayDraw(this.traits, this, this.graphics, this._scene);
   }
 
   canUpgrade(): boolean {

--- a/src/entities/Tower.ts
+++ b/src/entities/Tower.ts
@@ -313,17 +313,6 @@ export class Tower {
       }
     }
 
-    // Show link indicator on aura towers connected via Conduit
-    if ((this as any)._linkedByConduit) {
-      this.graphics.lineStyle(1, 0xffcc44, 0.5);
-      this.graphics.strokeCircle(this.x, this.y, s + 5);
-      // Faint line back to conduit
-      if ((this as any)._conduitX !== undefined) {
-        this.graphics.lineStyle(1, 0xffcc44, 0.15);
-        this.graphics.lineBetween(this.x, this.y, (this as any)._conduitX, (this as any)._conduitY);
-      }
-    }
-
     // Harmonic aura range indicators (each type has distinct color)
     if (hasTrait(this.traits, 'damage_aura')) {
       this.graphics.lineStyle(1, 0xff4444, 0.2); // red

--- a/src/main.ts
+++ b/src/main.ts
@@ -28,6 +28,7 @@ import './systems/traits/TowerTraitHandlers';
 import './systems/traits/CreepTraitHandlers';
 import './systems/traits/handlers/ChannelCasterHandler';
 import './systems/sabotage/SabotageTraits';
+import './systems/finale/FinaleTraits';
 
 // Eager-load the live-capture module so window.__learningCapture is
 // available from the menu (before any match starts). Module is

--- a/src/main.ts
+++ b/src/main.ts
@@ -27,6 +27,7 @@ import { PlayerProfile } from './systems/profile/PlayerProfile';
 import './systems/traits/TowerTraitHandlers';
 import './systems/traits/CreepTraitHandlers';
 import './systems/traits/handlers/ChannelCasterHandler';
+import './systems/sabotage/SabotageTraits';
 
 // Eager-load the live-capture module so window.__learningCapture is
 // available from the menu (before any match starts). Module is

--- a/src/scenes/GameScene.ts
+++ b/src/scenes/GameScene.ts
@@ -2243,8 +2243,8 @@ export class GameScene extends Phaser.Scene {
       // throne embedded tower). Player can inspect HP / stats but not
       // sell/upgrade.
       owned: tower.ownerIndex !== CPU_INDEX && this.canModifyTower(tower.col, tower.row),
-      hp: tower.hp,
-      maxHp: tower.maxHp,
+      hp: tower.destructible?.hp,
+      maxHp: tower.destructible?.maxHp,
       traits,
       auraBuffs,
       upgradePreview,

--- a/src/scenes/GameScene.ts
+++ b/src/scenes/GameScene.ts
@@ -1248,19 +1248,13 @@ export class GameScene extends Phaser.Scene {
       ? this._missionSuppressionPylons
       : mapDef.suppressionPylons;
     if (pylons && pylons.length > 0) {
-      this._suppressionMgr = new SuppressionManager(pylons);
+      // SuppressionManager validates pylon cells against the grid:
+      // auto-converts Empty → NoBuild so the click handler's pylon-
+      // channel intercept stays load-bearing, and loudly warns if a
+      // pylon ended up on Entry/Exit/Blocked/Tower (downstream
+      // assumptions would fragment in that case).
+      this._suppressionMgr = new SuppressionManager(pylons, this.grid);
       this._suppressionRender = new SuppressionRender(this);
-      // Mark pylon cells as noBuild so the player can't drop a tower on
-      // top of one. The click handler at the top of handleClick already
-      // intercepts pylon-cell clicks for channeling — without this, a
-      // build-mode click on a pylon cell would silently fail validation
-      // somewhere further down OR the cell would accept a build that
-      // visually overlaps the pylon. Marking noBuild surfaces the
-      // invariant cleanly at the grid layer.
-      for (const p of pylons) {
-        const row = this.grid.cells[p.row];
-        if (row && row[p.col] === CellType.Empty) row[p.col] = CellType.NoBuild;
-      }
     }
     // Mech M10 finale — instantiate the SabotageController. Reuses
     // the destructibleTowers map field (with isGenerator/isThrone tags

--- a/src/systems/TowerManager.ts
+++ b/src/systems/TowerManager.ts
@@ -8,7 +8,7 @@ import { StatsTracker } from './StatsTracker';
 import { EventLog } from '../ui/EventLog';
 import { getTowerType, TowerType } from '../data/TowerTypes';
 import { DraftModifier } from '../data/DraftModifiers';
-import { UpdateContext } from './traits/Trait';
+import { UpdateContext, removeTrait } from './traits/Trait';
 import { Tower } from '../entities/Tower';
 import { Creep } from '../entities/Creep';
 
@@ -159,9 +159,11 @@ export class TowerManager {
     // here would silently downgrade linear-upgraded towers back to L1
     // range every frame they're under a Reach.
     for (const tower of this.towers) {
-      (tower as any)._linkedByConduit = false;
-      (tower as any)._conduitX = undefined;
-      (tower as any)._conduitY = undefined;
+      // Strip the previous frame's conduit-linked trait — the
+      // conduit_link handler below re-stamps it on towers that are
+      // still in range. The trait carries srcX/srcY for the overlay
+      // line back to the conduit source.
+      removeTrait(tower.traits, 'conduit_linked');
       for (const trait of tower.traits) {
         if (trait.id === '_harmonic_damage' || trait.id === '_harmonic_rate' || trait.id === '_harmonic_range') {
           // multiplicative identity — every aura source compounds onto

--- a/src/systems/finale/FinaleController.ts
+++ b/src/systems/finale/FinaleController.ts
@@ -432,7 +432,7 @@ export class FinaleController {
         const rangeSq = t.range * t.range;
         // ─── Tier 1: creeps_attacking_it (sends that recently hit it) ───
         let target: { x: number; y: number; isHero?: boolean; creep?: Creep } | null = null;
-        if (now - t._lastSendHitAt < ATTACKING_WINDOW_MS) {
+        if (now - t.assailants.lastBy('send') < ATTACKING_WINDOW_MS) {
           let bestDist = Infinity;
           for (const c of creeps as Creep[]) {
             if (!c.alive || c.reached || !c.isSend) continue;
@@ -443,7 +443,7 @@ export class FinaleController {
           }
         }
         // ─── Tier 2: hero_attacking_it (hero recently hit it) ───
-        if (!target && hero && hero.alive && now - t._lastHeroHitAt < ATTACKING_WINDOW_MS) {
+        if (!target && hero && hero.alive && now - t.assailants.lastBy('hero') < ATTACKING_WINDOW_MS) {
           const dx = heroX - t.x, dy = heroY - t.y;
           if (dx * dx + dy * dy <= rangeSq) {
             target = { x: heroX, y: heroY, isHero: true };
@@ -615,9 +615,8 @@ export class FinaleController {
           alive: target.alive,
           path: pathPx,
           takeDamage: (amount: number) => {
-            const killed = target.takeDamage(amount);
+            const killed = target.takeDamage(amount, 'send');
             fd?.spawn?.(target.x, target.y - 18, String(amount), '#ffaa44');
-            (target as { _lastSendHitAt?: number })._lastSendHitAt = (this.scene as { time?: { now: number } }).time?.now ?? 0;
             return killed;
           },
         };
@@ -636,7 +635,7 @@ export class FinaleController {
     // tower falls, the shield drops.
     let aliveTowerCount = 0;
     for (const t of this.cpuTowers) {
-      if (!(t as { _expired?: boolean })._expired && (t.hp ?? 0) > 0) aliveTowerCount++;
+      if (!(t as { _expired?: boolean })._expired && (t.destructible?.hp ?? 0) > 0) aliveTowerCount++;
     }
     for (const s of this.cpuStructures) {
       s.invulnerable = s.isMissionWinTarget && aliveTowerCount > 0;
@@ -670,7 +669,7 @@ export class FinaleController {
     if (!this.winFired && this.firstSpawnDone) {
       let aliveTowers = 0;
       for (const t of this.cpuTowers) {
-        if (!(t as { _expired?: boolean })._expired && (t.hp ?? 0) > 0) aliveTowers++;
+        if (!(t as { _expired?: boolean })._expired && (t.destructible?.hp ?? 0) > 0) aliveTowers++;
       }
       let aliveWinTargets = 0;
       for (const s of this.cpuStructures) {
@@ -896,7 +895,7 @@ export class FinaleController {
 
   /** Snapshot of all alive CPU towers. Used by win-check + UI. */
   getCpuTowers(): Tower[] {
-    return this.cpuTowers.filter(t => !(t as { _expired?: boolean })._expired && (t.hp ?? 1) > 0);
+    return this.cpuTowers.filter(t => !(t as { _expired?: boolean })._expired && (t.destructible?.hp ?? 1) > 0);
   }
 
   /** Sprite-based projectile from a tower to the hero. Uses the

--- a/src/systems/finale/FinaleController.ts
+++ b/src/systems/finale/FinaleController.ts
@@ -149,11 +149,12 @@ export class FinaleController {
     this.onWin = args.onWin;
 
     // Place destructible CPU towers via the shared helper. Caller
-    // here just stamps the Arcane-specific isUlt flag.
+    // here pushes the arcane_ult_target trait on the ult tower so
+    // its golden HP-bar border + ult-tier kill rewards trigger.
     const ownerIndex = this.rules.cpuTowerOwnerIndex ?? CPU_INDEX;
     const defaultHp = this.rules.cpuTowerHpDefault ?? 600;
     for (const { spec, tower } of placeCpuTowers(this.towerMgr, args.destructibleTowers, ownerIndex, defaultHp)) {
-      if (spec.isUlt) tower.isUlt = true;
+      if (spec.isUlt) tower.traits.push({ id: 'arcane_ult_target' });
       this.cpuTowers.push(tower);
     }
 
@@ -511,8 +512,9 @@ export class FinaleController {
         for (const t of this.cpuTowers) {
           if ((t as { _expired?: boolean })._expired && !(t as { _killRewardGranted?: boolean })._killRewardGranted) {
             (t as { _killRewardGranted?: boolean })._killRewardGranted = true;
-            const gold = t.isUlt ? (reward.ultGold ?? 500) : (reward.gold ?? 50);
-            const xp = t.isUlt ? (reward.ultXp ?? 250) : (reward.xp ?? 50);
+            const isUlt = t.traits.some(tr => tr.id === 'arcane_ult_target');
+            const gold = isUlt ? (reward.ultGold ?? 500) : (reward.gold ?? 50);
+            const xp = isUlt ? (reward.ultXp ?? 250) : (reward.xp ?? 50);
             const econ = (this.scene as { economy?: { addGold: (n: number) => void } }).economy;
             econ?.addGold?.(gold);
             this.hero.grantXP(xp);
@@ -531,7 +533,7 @@ export class FinaleController {
               });
             }
             const log = (this.scene as { eventLog?: { gameMessage?: (s: string) => void } }).eventLog;
-            log?.gameMessage?.(t.isUlt
+            log?.gameMessage?.(isUlt
               ? `THE THRONE FALLS — ${gold}g, ${xp}xp.`
               : `Defender tower destroyed (+${gold}g, +${xp}xp).`);
           }

--- a/src/systems/finale/FinaleController.ts
+++ b/src/systems/finale/FinaleController.ts
@@ -41,7 +41,7 @@ import { gridX, gridY, GRID_COLS, GRID_ROWS, TILE_SIZE, getGridOffsetX, pixelToC
 import { Grid, CellType } from '../Grid';
 import { findPath, PathPoint } from '../Pathfinding';
 import { createProjectileSprite, hasProjectileSprite } from '../SpriteManager';
-import { Damageable } from './Damageable';
+import { Damageable } from '../../entities/Damageable';
 import { placeCpuTowers } from './cpuPlacement';
 import { dispatchFinaleEffect } from './FinaleEffects';
 import { applyHeroPendingEffects, PendingHittable } from './applyHeroPendingEffects';

--- a/src/systems/finale/FinaleTraits.ts
+++ b/src/systems/finale/FinaleTraits.ts
@@ -1,0 +1,37 @@
+/**
+ * Arcane-finale trait registrations. Currently one entry — the
+ * `arcane_ult_target` trait that marks a tower as the M10 win-target
+ * and registers its golden HP-bar border via the v2 overlay-draw
+ * pipeline. Future finale-only behaviours (rage-phase modifiers,
+ * channel-amplifier visuals, etc.) hang off the same module.
+ *
+ * Side-effect imported from main.ts.
+ */
+
+import { registerOverlayDraw } from '../traits/Trait';
+import { TILE_SIZE } from '../../config';
+import type { Tower } from '../../entities/Tower';
+
+/** Marks the Arcane M10 throne tower so its HP bar gets a golden
+ *  border treatment + kill-reward in FinaleController uses the
+ *  ult-tier reward keys. Purely declarative — the rendering effect
+ *  lives in the overlay-draw handler below; FinaleController reads
+ *  hasTrait(...) for the reward branch. */
+export interface ArcaneUltTargetTrait {
+  id: 'arcane_ult_target';
+}
+
+// Golden HP-bar border overlay. Reads tower.destructible to position
+// the bar identically to the base render in Tower.drawTower (same
+// pixel offsets); short-circuits when not destructible or HP is full
+// (no bar visible, no border to draw on top of nothing).
+registerOverlayDraw('arcane_ult_target', (_trait, tower: Tower, graphics) => {
+  const d = tower.destructible;
+  if (!d || d.maxHp <= 0 || d.hp >= d.maxHp) return;
+  const w = TILE_SIZE * 0.8;
+  const h = 3;
+  const x = tower.x - w / 2;
+  const y = tower.y - TILE_SIZE * 0.55;
+  graphics.lineStyle(1, 0xffdd44, 1);
+  graphics.strokeRect(x, y, w, h);
+});

--- a/src/systems/finale/cpuPlacement.ts
+++ b/src/systems/finale/cpuPlacement.ts
@@ -13,6 +13,7 @@
 import type { Tower } from '../../entities/Tower';
 import type { TowerManager } from '../TowerManager';
 import { getTowerType } from '../../data/TowerTypes';
+import { createDestructibleState } from '../../entities/Destructibility';
 
 export interface BaseCpuTowerSpec {
   col: number;
@@ -52,10 +53,8 @@ export function placeCpuTowers<T extends BaseCpuTowerSpec>(
       );
       if (!result) continue;
       const t = result.tower;
-      t.destructible = true;
       t.ownerIndex = ownerIndex;
-      t.maxHp = spec.hp ?? defaultHp;
-      t.hp = t.maxHp;
+      t.destructible = createDestructibleState(spec.hp ?? defaultHp);
       out.push({ spec, tower: t });
     } catch (err) {
       console.warn(`[cpuPlacement] failed to place ${spec.towerId} at ${spec.col},${spec.row}:`, err);

--- a/src/systems/sabotage/SabotageController.test.ts
+++ b/src/systems/sabotage/SabotageController.test.ts
@@ -7,8 +7,9 @@ import { createAssailantLog } from '../../entities/Damageable';
 /** Minimal Tower stand-in. Mimics the fields SabotageController reads
  *  + a takeDamage that drives hp to zero and sets _expired. Mirrors
  *  the v2 destructible sub-object shape — cpuPlacement stamps the
- *  state via createDestructibleState, so the mock just needs the
- *  initial null + a takeDamage that flows through the sub-object. */
+ *  state via createDestructibleState; the controller pushes
+ *  mech_generator / mech_throne / invulnerable trait entries onto
+ *  `traits`. */
 function makeTower(col: number, row: number): Partial<Tower> {
   const t: any = {
     col, row,
@@ -16,14 +17,15 @@ function makeTower(col: number, row: number): Partial<Tower> {
     assailants: createAssailantLog(),
     ownerIndex: 0,
     _expired: false,
-    _invulnerable: false,
-    isGenerator: false,
-    isThrone: false,
-    generatorLinkedCells: undefined,
+    traits: [],
     takeDamage(amount: number) {
       if (!this.destructible) return false;
       if (this.destructible.hp <= 0) return false;
-      if (this._invulnerable) return false;
+      // Mirror the trait-veto check: if the tower carries an
+      // 'invulnerable' trait, the real Tower.takeDamage would return
+      // false at the veto step. Match that here so tests asserting
+      // "kill throne while generators alive is a no-op" pass.
+      if (this.traits.some((tr: { id: string }) => tr.id === 'invulnerable')) return false;
       this.destructible.hp -= amount;
       if (this.destructible.hp <= 0) {
         this.destructible.hp = 0;
@@ -94,8 +96,9 @@ describe('SabotageController', () => {
     });
     expect(ctrl.getTotalGeneratorCount()).toBe(1);
     expect(ctrl.getAliveGeneratorCount()).toBe(1);
-    expect(ctrl.getThrone()?._invulnerable).toBe(true);
-    expect(ctrl.getThrone()?.isThrone).toBe(true);
+    const throneTraits = ctrl.getThrone()?.traits.map(t => t.id) ?? [];
+    expect(throneTraits).toContain('invulnerable');
+    expect(throneTraits).toContain('mech_throne');
   });
 
   it('expires linked towers when the generator dies', () => {
@@ -132,15 +135,16 @@ describe('SabotageController', () => {
       ],
       onThroneVulnerable,
     });
-    expect(ctrl.getThrone()?._invulnerable).toBe(true);
+    const hasInvuln = () => ctrl.getThrone()?.traits.some(t => t.id === 'invulnerable') ?? false;
+    expect(hasInvuln()).toBe(true);
     const [g1, g2] = (mgr.towers as any).slice(0, 2);
     g1.takeDamage(100);
     ctrl.update();
-    expect(ctrl.getThrone()?._invulnerable).toBe(true);
+    expect(hasInvuln()).toBe(true);
     expect(onThroneVulnerable).not.toHaveBeenCalled();
     g2.takeDamage(100);
     ctrl.update();
-    expect(ctrl.getThrone()?._invulnerable).toBe(false);
+    expect(hasInvuln()).toBe(false);
     expect(onThroneVulnerable).toHaveBeenCalledTimes(1);
     ctrl.update();
     expect(onThroneVulnerable).toHaveBeenCalledTimes(1);
@@ -175,7 +179,7 @@ describe('SabotageController', () => {
     });
     ctrl.update();
     const throne = ctrl.getThrone()!;
-    expect(throne._invulnerable).toBe(false);
+    expect(throne.traits.some(t => t.id === 'invulnerable')).toBe(false);
     (throne as any).takeDamage(100);
     ctrl.update();
     expect(onWin).toHaveBeenCalledTimes(1);

--- a/src/systems/sabotage/SabotageController.test.ts
+++ b/src/systems/sabotage/SabotageController.test.ts
@@ -2,15 +2,18 @@ import { describe, expect, it, vi } from 'vitest';
 import { SabotageController } from './SabotageController';
 import type { Tower } from '../../entities/Tower';
 import type { TowerManager } from '../TowerManager';
+import { createAssailantLog } from '../../entities/Damageable';
 
 /** Minimal Tower stand-in. Mimics the fields SabotageController reads
- *  + a takeDamage that drives hp to zero and sets _expired. */
+ *  + a takeDamage that drives hp to zero and sets _expired. Mirrors
+ *  the v2 destructible sub-object shape — cpuPlacement stamps the
+ *  state via createDestructibleState, so the mock just needs the
+ *  initial null + a takeDamage that flows through the sub-object. */
 function makeTower(col: number, row: number): Partial<Tower> {
   const t: any = {
     col, row,
-    hp: undefined,
-    maxHp: undefined,
-    destructible: false,
+    destructible: null,
+    assailants: createAssailantLog(),
     ownerIndex: 0,
     _expired: false,
     _invulnerable: false,
@@ -18,12 +21,12 @@ function makeTower(col: number, row: number): Partial<Tower> {
     isThrone: false,
     generatorLinkedCells: undefined,
     takeDamage(amount: number) {
-      if (!this.destructible || this.hp === undefined) return false;
-      if (this.hp <= 0) return false;
+      if (!this.destructible) return false;
+      if (this.destructible.hp <= 0) return false;
       if (this._invulnerable) return false;
-      this.hp -= amount;
-      if (this.hp <= 0) {
-        this.hp = 0;
+      this.destructible.hp -= amount;
+      if (this.destructible.hp <= 0) {
+        this.destructible.hp = 0;
         this._expired = true;
         return true;
       }
@@ -108,7 +111,7 @@ describe('SabotageController', () => {
       onGeneratorKilled,
     });
     const generator = (mgr.towers as any)[2] as Partial<Tower>;
-    generator.takeDamage!(generator.maxHp!);
+    generator.takeDamage!(generator.destructible!.maxHp);
     ctrl.update();
     const linked1 = (mgr.towers as any)[0];
     const linked2 = (mgr.towers as any)[1];
@@ -154,7 +157,7 @@ describe('SabotageController', () => {
     });
     const throne = (mgr.towers as any)[1];
     throne.takeDamage(9999);
-    expect(throne.hp).toBe(1000);
+    expect(throne.destructible.hp).toBe(1000);
     expect(throne._expired).toBe(false);
   });
 
@@ -212,8 +215,8 @@ describe('SabotageController', () => {
       ],
     });
     const throne = (mgr.towers as any)[0];
-    expect(throne.maxHp).toBe(999);
-    expect(throne.hp).toBe(999);
+    expect(throne.destructible.maxHp).toBe(999);
+    expect(throne.destructible.hp).toBe(999);
   });
 
   describe('workshop + raider squad integration', () => {
@@ -330,7 +333,7 @@ describe('SabotageController', () => {
         onWin,
       });
       expect(ctrl.forceKillTarget('throne')).toBe(false);
-      expect(ctrl.getThrone()?.hp).toBe(5000);
+      expect(ctrl.getThrone()?.destructible?.hp).toBe(5000);
       expect(onWin).not.toHaveBeenCalled();
     });
 

--- a/src/systems/sabotage/SabotageController.ts
+++ b/src/systems/sabotage/SabotageController.ts
@@ -36,6 +36,7 @@ import {
   GENERATOR_TEXTURE,
   generatorFrameForHp,
 } from './SabotageAssets';
+import { getTrait, hasTrait, removeTrait } from '../traits/Trait';
 import type * as Phaser from 'phaser';
 
 export const CPU_INDEX_SABOTAGE = 99;
@@ -120,6 +121,12 @@ export class SabotageController {
   private cpuStructures: DestructibleStructure[] = [];
   private throneVulnerableFired = false;
   private winFired = false;
+  /** Controller-private bookkeeping: generators whose linked-tower
+   *  cascade has already fired. Replaces the per-tower
+   *  `_generatorDrained` flag (cleaner separation — tower entities
+   *  don't carry per-controller state). WeakSet so the entries free
+   *  when towers are cleaned up. */
+  private _drained: WeakSet<Tower> = new WeakSet();
   private onWin?: () => void;
   private onThroneKilled?: () => void;
   private onThroneVulnerable?: () => void;
@@ -168,8 +175,7 @@ export class SabotageController {
     const defaultHp = this.rules.cpuTowerHpDefault ?? 600;
     for (const { spec, tower } of placeCpuTowers(this.towerMgr, args.destructibleTowers, ownerIndex, defaultHp)) {
       if (spec.isGenerator) {
-        tower.isGenerator = true;
-        tower.generatorLinkedCells = spec.linkedTowers ?? [];
+        tower.traits.push({ id: 'mech_generator', linkedCells: spec.linkedTowers ?? [] });
         // Generators are inert HP bags — never fire. Block the
         // standard updateTowers pipeline from picking them via the
         // existing _disabledRemaining channel (Infinity stays Infinity
@@ -182,8 +188,8 @@ export class SabotageController {
         this.generators.push(tower);
       }
       if (spec.isThrone) {
-        tower.isThrone = true;
-        tower._invulnerable = true;
+        tower.traits.push({ id: 'mech_throne' });
+        tower.traits.push({ id: 'invulnerable' });
         this.throne = tower;
       }
       this.cpuTowers.push(tower);
@@ -243,30 +249,33 @@ export class SabotageController {
 
     // Drain any newly-dead generators we haven't processed yet. Death
     // is detected by hp<=0 (Tower.takeDamage drives it to 0 and sets
-    // _expired); the per-tower _generatorDrained flag prevents double-
-    // firing the cascade across multiple updates after death.
+    // _expired). The per-controller _drained WeakSet (not a per-tower
+    // flag — bookkeeping is controller-private) prevents double-firing
+    // the cascade across multiple updates after death.
     for (let i = 0; i < this.generators.length; i++) {
       const gen = this.generators[i];
       if ((gen.destructible?.hp ?? 1) > 0) continue;
-      if (gen._generatorDrained) continue;
-      gen._generatorDrained = true;
+      if (this._drained.has(gen)) continue;
+      this._drained.add(gen);
       this.onGeneratorKilled?.(i);
-      for (const cell of gen.generatorLinkedCells ?? []) {
+      const genTrait = getTrait(gen.traits, 'mech_generator') as { linkedCells: { col: number; row: number }[] } | undefined;
+      for (const cell of genTrait?.linkedCells ?? []) {
         const target = this.cpuTowers.find(t => t.col === cell.col && t.row === cell.row && !t._expired);
         if (!target) continue;
         target._expired = true;
       }
     }
 
-    // Throne becomes mortal once every generator is gone. Handles both
-    // the legacy single-cell Tower path AND the PRD-06 structure path
-    // — whichever the map uses, the controller flips its invulnerable
-    // flag in lockstep.
+    // Throne becomes mortal once every generator is gone. Removing the
+    // 'invulnerable' trait flips the damage-veto pipeline — the
+    // Damageable.takeDamage path now applies damage normally. For the
+    // structure-throne (PRD-06), we still flip its boolean directly
+    // since DestructibleStructure doesn't carry traits.
     if (!this.throneVulnerableFired && this._allGeneratorsDead()) {
       const hasThrone = this.throne !== null || this.throneStructure !== null;
       if (hasThrone) {
         this.throneVulnerableFired = true;
-        if (this.throne) this.throne._invulnerable = false;
+        if (this.throne) removeTrait(this.throne.traits, 'invulnerable');
         if (this.throneStructure) this.throneStructure.invulnerable = false;
         this.onThroneVulnerable?.();
       }
@@ -441,7 +450,7 @@ export class SabotageController {
     if (this.throne) {
       throne = {
         alive: !this.throne._expired && (this.throne.destructible?.hp ?? 0) > 0,
-        invulnerable: this.throne._invulnerable,
+        invulnerable: hasTrait(this.throne.traits, 'invulnerable'),
         hp: this.throne.destructible?.hp ?? 0,
         maxHp: this.throne.destructible?.maxHp ?? 0,
       };
@@ -498,7 +507,7 @@ export class SabotageController {
       // targets (kill = linked-tower cascade) but don't shoot. Skipping
       // them here also avoids the placeholder mech_mortar visual
       // splash-killing the squad with each tick.
-      if (tower.isGenerator) continue;
+      if (hasTrait(tower.traits, 'mech_generator')) continue;
       // Tower fired this tick already (at a send via standard path).
       if (now - tower.lastFired < tower.fireRate) continue;
       const target = this._closestRaiderInRange(tower);

--- a/src/systems/sabotage/SabotageController.ts
+++ b/src/systems/sabotage/SabotageController.ts
@@ -247,7 +247,7 @@ export class SabotageController {
     // firing the cascade across multiple updates after death.
     for (let i = 0; i < this.generators.length; i++) {
       const gen = this.generators[i];
-      if ((gen.hp ?? 1) > 0) continue;
+      if ((gen.destructible?.hp ?? 1) > 0) continue;
       if (gen._generatorDrained) continue;
       gen._generatorDrained = true;
       this.onGeneratorKilled?.(i);
@@ -319,7 +319,7 @@ export class SabotageController {
     // Win = throne destroyed. Handles both paths — Tower throne dies
     // when _expired or hp<=0; Structure throne dies when !alive.
     if (!this.winFired) {
-      const throneDeadTower = this.throne && (this.throne._expired || (this.throne.hp ?? 1) <= 0);
+      const throneDeadTower = this.throne && (this.throne._expired || (this.throne.destructible?.hp ?? 1) <= 0);
       const throneDeadStructure = this.throneStructure && !this.throneStructure.alive;
       if (throneDeadTower || throneDeadStructure) {
         this.winFired = true;
@@ -400,7 +400,7 @@ export class SabotageController {
    *  the throne-vulnerability gate; exposed so HUD code can render
    *  "X / N generators down" without poking internals. */
   getAliveGeneratorCount(): number {
-    return this.generators.filter(g => !g._expired && (g.hp ?? 0) > 0).length;
+    return this.generators.filter(g => !g._expired && (g.destructible?.hp ?? 0) > 0).length;
   }
 
   getTotalGeneratorCount(): number {
@@ -433,17 +433,17 @@ export class SabotageController {
   } {
     const generators = this.generators.map((g, idx) => ({
       idx,
-      alive: !g._expired && (g.hp ?? 0) > 0,
-      hp: g.hp ?? 0,
-      maxHp: g.maxHp ?? 0,
+      alive: !g._expired && (g.destructible?.hp ?? 0) > 0,
+      hp: g.destructible?.hp ?? 0,
+      maxHp: g.destructible?.maxHp ?? 0,
     }));
     let throne: { alive: boolean; invulnerable: boolean; hp: number; maxHp: number } | null = null;
     if (this.throne) {
       throne = {
-        alive: !this.throne._expired && (this.throne.hp ?? 0) > 0,
+        alive: !this.throne._expired && (this.throne.destructible?.hp ?? 0) > 0,
         invulnerable: this.throne._invulnerable,
-        hp: this.throne.hp ?? 0,
-        maxHp: this.throne.maxHp ?? 0,
+        hp: this.throne.destructible?.hp ?? 0,
+        maxHp: this.throne.destructible?.maxHp ?? 0,
       };
     } else if (this.throneStructure) {
       throne = {
@@ -467,13 +467,13 @@ export class SabotageController {
     if (kind === 'generator') {
       if (idx === undefined || idx < 0 || idx >= this.generators.length) return false;
       const gen = this.generators[idx];
-      if (gen._expired || (gen.hp ?? 0) <= 0) return false;
-      gen.takeDamage(gen.maxHp ?? gen.hp ?? 1);
+      if (gen._expired || (gen.destructible?.hp ?? 0) <= 0) return false;
+      gen.takeDamage(gen.destructible?.maxHp ?? 1);
       return true;
     }
     if (this.throne) {
-      if (this.throne._expired || (this.throne.hp ?? 0) <= 0) return false;
-      return this.throne.takeDamage(this.throne.maxHp ?? this.throne.hp ?? 1);
+      if (this.throne._expired || (this.throne.destructible?.hp ?? 0) <= 0) return false;
+      return this.throne.takeDamage(this.throne.destructible?.maxHp ?? 1);
     }
     if (this.throneStructure) {
       if (!this.throneStructure.alive) return false;
@@ -493,7 +493,7 @@ export class SabotageController {
     if (this.raiders.length === 0) return;
     for (const tower of this.cpuTowers) {
       if (tower._expired) continue;
-      if (tower.hp !== undefined && tower.hp <= 0) continue;
+      if (tower.destructible && tower.destructible.hp <= 0) continue;
       // Generators are inert HP bags — they're strategic priority
       // targets (kill = linked-tower cascade) but don't shoot. Skipping
       // them here also avoids the placeholder mech_mortar visual

--- a/src/systems/sabotage/SabotageRender.ts
+++ b/src/systems/sabotage/SabotageRender.ts
@@ -130,7 +130,8 @@ export class SabotageRender {
       // F0 — "shield up". The throne is invulnerable while any
       // generator is alive, so F0 stays pinned until SabotageController
       // flips _invulnerable. Once mortal, frame tracks HP.
-      const frame = throne._invulnerable ? 0 : throneFrameForHp(throne.destructible.hp / throne.destructible.maxHp);
+      const invulnerable = throne.traits.some(t => t.id === 'invulnerable');
+      const frame = invulnerable ? 0 : throneFrameForHp(throne.destructible.hp / throne.destructible.maxHp);
       throne.sprite.setFrame(frame);
     }
   }
@@ -157,7 +158,8 @@ export class SabotageRender {
     for (const gen of controller.getGenerators()) {
       if (gen._expired) continue;
       if (gen.destructible && gen.destructible.hp <= 0) continue;
-      const cells = gen.generatorLinkedCells ?? [];
+      const genTrait = gen.traits.find(t => t.id === 'mech_generator') as { linkedCells?: { col: number; row: number }[] } | undefined;
+      const cells = genTrait?.linkedCells ?? [];
       if (cells.length === 0) continue;
       // HP-scaled alpha so the visual fades as the generator weakens
       // (a hint that the link is about to break).

--- a/src/systems/sabotage/SabotageRender.ts
+++ b/src/systems/sabotage/SabotageRender.ts
@@ -122,15 +122,15 @@ export class SabotageRender {
   private syncDamageFrames(controller: SabotageController): void {
     for (const gen of controller.getGenerators()) {
       if (gen._expired) continue;
-      if (!gen.sprite || gen.maxHp === undefined || gen.hp === undefined) continue;
-      gen.sprite.setFrame(generatorFrameForHp(gen.hp / gen.maxHp));
+      if (!gen.sprite || !gen.destructible) continue;
+      gen.sprite.setFrame(generatorFrameForHp(gen.destructible.hp / gen.destructible.maxHp));
     }
     const throne = controller.getThrone();
-    if (throne && throne.sprite && throne.maxHp !== undefined && throne.hp !== undefined) {
+    if (throne && throne.sprite && throne.destructible) {
       // F0 — "shield up". The throne is invulnerable while any
       // generator is alive, so F0 stays pinned until SabotageController
       // flips _invulnerable. Once mortal, frame tracks HP.
-      const frame = throne._invulnerable ? 0 : throneFrameForHp(throne.hp / throne.maxHp);
+      const frame = throne._invulnerable ? 0 : throneFrameForHp(throne.destructible.hp / throne.destructible.maxHp);
       throne.sprite.setFrame(frame);
     }
   }
@@ -156,12 +156,12 @@ export class SabotageRender {
   private drawGeneratorPowerLines(controller: SabotageController, now: number): void {
     for (const gen of controller.getGenerators()) {
       if (gen._expired) continue;
-      if (gen.hp !== undefined && gen.hp <= 0) continue;
+      if (gen.destructible && gen.destructible.hp <= 0) continue;
       const cells = gen.generatorLinkedCells ?? [];
       if (cells.length === 0) continue;
       // HP-scaled alpha so the visual fades as the generator weakens
       // (a hint that the link is about to break).
-      const hpRatio = gen.maxHp ? Math.max(0, (gen.hp ?? 0) / gen.maxHp) : 1;
+      const hpRatio = gen.destructible ? Math.max(0, gen.destructible.hp / gen.destructible.maxHp) : 1;
       const baseAlpha = 0.25 + 0.25 * hpRatio;
       for (const cell of cells) {
         const target = controller.findCpuTowerAt(cell.col, cell.row);

--- a/src/systems/sabotage/SabotageTraits.ts
+++ b/src/systems/sabotage/SabotageTraits.ts
@@ -1,0 +1,48 @@
+/**
+ * Mechanical-campaign trait registrations. Each Mech-specific tower
+ * "tag" that lived on Tower.ts as a flag before the v2 refactor is now
+ * a trait registered here:
+ *
+ *   - mech_generator (with linkedCells: Coord[] payload)
+ *   - mech_throne (marker)
+ *   - invulnerable (generic damage-veto; reusable for any future
+ *                   campaign mechanic that wants "no damage right now")
+ *
+ * SabotageController adds these to a tower's traits[] at placement
+ * time and removes the invulnerable trait when the generator cascade
+ * lifts. The damage-veto handler returns true for any invulnerable
+ * tower, so Tower.takeDamage's pipeline short-circuits silently.
+ *
+ * Import as a side-effect (`import './SabotageTraits'`) so the
+ * registrations apply before any tower is constructed.
+ */
+
+import { registerDamageVeto } from '../traits/Trait';
+
+export interface MechGeneratorTrait {
+  id: 'mech_generator';
+  /** Cells of CPU towers this generator powers. When the generator
+   *  dies, SabotageController kills every linked tower (sets
+   *  _expired = true, no rewards). Empty for "standalone" generators
+   *  that don't cascade. */
+  linkedCells: { col: number; row: number }[];
+}
+
+export interface MechThroneTrait {
+  id: 'mech_throne';
+}
+
+/** Generic damage-veto trait. Present on a tower = takeDamage no-ops.
+ *  Carried by the Mech throne while any generator is alive, but
+ *  reusable for future mechanics (Cypherpunk shielded servers,
+ *  boss-phase invuln windows, etc.). Cosmetics (shield ring, etc.)
+ *  belong on a separate overlay-draw trait so the veto stays
+ *  primitive. */
+export interface InvulnerableTrait {
+  id: 'invulnerable';
+}
+
+// The veto handler is intentionally trivial — the marker presence
+// IS the contract. Future variants (mute_window with a TTL, hp-
+// gated vulnerability, etc.) get their own ids.
+registerDamageVeto('invulnerable', () => true);

--- a/src/systems/suppression/SuppressionManager.test.ts
+++ b/src/systems/suppression/SuppressionManager.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it, vi } from 'vitest';
-import { SIPHON_STACK_THRESHOLD, SuppressionManager, type SuppressibleTower } from './SuppressionManager';
+import { SIPHON_STACK_THRESHOLD, SuppressionManager, type SuppressibleTower, type SuppressibleTraitState } from './SuppressionManager';
 import { CellType, Grid } from '../Grid';
 import { gridX, gridY, TILE_SIZE } from '../../config';
+import { getTrait } from '../traits/Trait';
 
 /** Minimal Grid stand-in with a fixed shape — no MapDefinition needed.
  *  Tests stamp specific cells; `cells[row][col]` is reachable as on
@@ -17,11 +18,17 @@ function makeTower(col: number, row: number, opts: Partial<SuppressibleTower> = 
   return {
     col, row,
     lastFired: 0,
-    _stress: 0,
     _disabledRemaining: 0,
-    _suppressionSeenLastFired: -Infinity,
+    traits: [],
     ...opts,
   };
+}
+
+/** Read the suppressible trait's stress, defaulting to 0 when the
+ *  manager hasn't attached the trait yet. Replaces the old `t._stress`
+ *  read pattern; the trait is lazy-attached on first fire-in-radius. */
+function stressOf(t: SuppressibleTower): number {
+  return (getTrait(t.traits, 'suppressible') as SuppressibleTraitState | undefined)?.stress ?? 0;
 }
 
 /** Simulate one tower fire by bumping `lastFired` and calling update. */
@@ -35,7 +42,7 @@ describe('SuppressionManager', () => {
     const mgr = new SuppressionManager([]);
     const t = makeTower(5, 5);
     for (let i = 0; i < 10; i++) fire(mgr, t, i + 1);
-    expect(t._stress).toBe(0);
+    expect(stressOf(t)).toBe(0);
     expect(t._disabledRemaining).toBe(0);
   });
 
@@ -43,7 +50,7 @@ describe('SuppressionManager', () => {
     const mgr = new SuppressionManager([{ col: 0, row: 0, radius: 2 }]);
     const t = makeTower(10, 10);
     for (let i = 0; i < 10; i++) fire(mgr, t, i + 1);
-    expect(t._stress).toBe(0);
+    expect(stressOf(t)).toBe(0);
   });
 
   it('increments stress on each fire when in radius', () => {
@@ -52,7 +59,7 @@ describe('SuppressionManager', () => {
     fire(mgr, t, 1);
     fire(mgr, t, 2);
     fire(mgr, t, 3);
-    expect(t._stress).toBe(3);
+    expect(stressOf(t)).toBe(3);
     expect(t._disabledRemaining).toBe(0);
   });
 
@@ -60,7 +67,7 @@ describe('SuppressionManager', () => {
     const mgr = new SuppressionManager([{ col: 5, row: 5, radius: 3 }]);
     const t = makeTower(5, 5);
     for (let i = 0; i < 5; i++) fire(mgr, t, i + 1);
-    expect(t._stress).toBe(0);
+    expect(stressOf(t)).toBe(0);
     expect(t._disabledRemaining).toBe(3);
   });
 
@@ -71,7 +78,7 @@ describe('SuppressionManager', () => {
     // Same lastFired — manager should not re-count.
     mgr.update(2, [t]);
     mgr.update(3, [t]);
-    expect(t._stress).toBe(1);
+    expect(stressOf(t)).toBe(1);
   });
 
   it('respects pylon Chebyshev radius edges', () => {
@@ -80,8 +87,8 @@ describe('SuppressionManager', () => {
     const outside = makeTower(8, 5);  // one beyond: |8-5| = 3
     fire(mgr, inside, 1);
     fire(mgr, outside, 1);
-    expect(inside._stress).toBe(1);
-    expect(outside._stress).toBe(0);
+    expect(stressOf(inside)).toBe(1);
+    expect(stressOf(outside)).toBe(0);
   });
 
   it('mute suppresses stress accumulation for the window', () => {
@@ -90,10 +97,10 @@ describe('SuppressionManager', () => {
     expect(mgr.mutePylonAt(5, 5, 1000, 5_000)).toBe(true);
     fire(mgr, t, 2000);
     fire(mgr, t, 3000);
-    expect(t._stress).toBe(0);
+    expect(stressOf(t)).toBe(0);
     // After the mute window expires, stress accumulates again.
     fire(mgr, t, 7_000);
-    expect(t._stress).toBe(1);
+    expect(stressOf(t)).toBe(1);
   });
 
   it('remute extends the mute window when the new end-time is later', () => {
@@ -102,9 +109,9 @@ describe('SuppressionManager', () => {
     expect(mgr.mutePylonAt(5, 5, 2000, 8_000)).toBe(true); // mute until 10000 — extends
     const t = makeTower(5, 5);
     fire(mgr, t, 9_500);
-    expect(t._stress).toBe(0);
+    expect(stressOf(t)).toBe(0);
     fire(mgr, t, 10_500);
-    expect(t._stress).toBe(1);
+    expect(stressOf(t)).toBe(1);
   });
 
   it('remute is a no-op when the new end-time is earlier', () => {
@@ -113,7 +120,7 @@ describe('SuppressionManager', () => {
     expect(mgr.mutePylonAt(5, 5, 1000, 2_000)).toBe(true);   // would mute until 3000 — ignored
     const t = makeTower(5, 5);
     fire(mgr, t, 5_000);
-    expect(t._stress).toBe(0); // longer mute still active
+    expect(stressOf(t)).toBe(0); // longer mute still active
   });
 
   it('mute returns false when no pylon at the cell', () => {
@@ -127,11 +134,11 @@ describe('SuppressionManager', () => {
     const t = makeTower(5, 5);
     // Mid-channel — pylon is still active, towers still suppressed.
     fire(mgr, t, 2000);
-    expect(t._stress).toBe(1);
+    expect(stressOf(t)).toBe(1);
     // After channel duration (2.5s default), update applies mute.
     mgr.update(1000 + mgr.getChannelDurationMs() + 1, []);
     fire(mgr, t, 5000);
-    expect(t._stress).toBe(1); // mute prevented further accumulation
+    expect(stressOf(t)).toBe(1); // mute prevented further accumulation
   });
 
   it('startChannelAt returns specific failure modes', () => {
@@ -155,21 +162,21 @@ describe('SuppressionManager', () => {
     mgr.update(10_000, []);
     const t = makeTower(5, 5);
     fire(mgr, t, 11_000);
-    expect(t._stress).toBe(1);
+    expect(stressOf(t)).toBe(1);
   });
 
   it('skips CPU-team towers (ownerIndex !== 0/undefined)', () => {
     const mgr = new SuppressionManager([{ col: 5, row: 5, radius: 3 }]);
     const cpu = makeTower(5, 5, { ownerIndex: 99 });
     for (let i = 0; i < 10; i++) fire(mgr, cpu, i + 1);
-    expect(cpu._stress).toBe(0);
+    expect(stressOf(cpu)).toBe(0);
   });
 
   it('skips expired towers', () => {
     const mgr = new SuppressionManager([{ col: 5, row: 5, radius: 3 }]);
     const t = makeTower(5, 5, { _expired: true });
     fire(mgr, t, 1);
-    expect(t._stress).toBe(0);
+    expect(stressOf(t)).toBe(0);
   });
 
   it('multiple pylons covering the same tower count once per fire', () => {
@@ -180,7 +187,7 @@ describe('SuppressionManager', () => {
     const t = makeTower(5, 5);
     fire(mgr, t, 1);
     fire(mgr, t, 2);
-    expect(t._stress).toBe(2); // not 4 — fire-once-per-tick semantics
+    expect(stressOf(t)).toBe(2); // not 4 — fire-once-per-tick semantics
   });
 
   it('pylonAt returns the right pylon', () => {

--- a/src/systems/suppression/SuppressionManager.test.ts
+++ b/src/systems/suppression/SuppressionManager.test.ts
@@ -1,6 +1,17 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { SIPHON_STACK_THRESHOLD, SuppressionManager, type SuppressibleTower } from './SuppressionManager';
+import { CellType, Grid } from '../Grid';
 import { gridX, gridY, TILE_SIZE } from '../../config';
+
+/** Minimal Grid stand-in with a fixed shape — no MapDefinition needed.
+ *  Tests stamp specific cells; `cells[row][col]` is reachable as on
+ *  the real Grid. */
+function makeGrid(rows = 20, cols = 30): Grid {
+  // Construct without a MapDefinition; the no-arg path initializes
+  // cells to Empty and skips entry/exit population.
+  const g = new Grid(undefined, rows, cols);
+  return g;
+}
 
 function makeTower(col: number, row: number, opts: Partial<SuppressibleTower> = {}): SuppressibleTower {
   return {
@@ -225,6 +236,75 @@ describe('SuppressionManager', () => {
     const pylon = mgr.pylons[0];
     expect(pylon.siphonStacks).toBe(0);
     expect(pylon.isActive(1000 + mgr.getChannelDurationMs() + 2)).toBe(false);
+  });
+
+  // ─── Pylon-cell invariant (grid auto-stamp + warning) ───────
+
+  describe('pylon-cell invariant', () => {
+    it('auto-converts Empty pylon cells to NoBuild', () => {
+      const grid = makeGrid();
+      new SuppressionManager([{ col: 5, row: 5 }], grid);
+      expect(grid.cells[5][5]).toBe(CellType.NoBuild);
+    });
+
+    it('leaves already-NoBuild cells untouched (idempotent)', () => {
+      const grid = makeGrid();
+      grid.cells[5][5] = CellType.NoBuild;
+      new SuppressionManager([{ col: 5, row: 5 }], grid);
+      expect(grid.cells[5][5]).toBe(CellType.NoBuild);
+    });
+
+    it('warns when a pylon sits on Entry/Exit/Blocked/Tower', () => {
+      const grid = makeGrid();
+      grid.cells[2][2] = CellType.Entry;
+      grid.cells[3][3] = CellType.Exit;
+      grid.cells[4][4] = CellType.Blocked;
+      grid.cells[6][6] = CellType.Tower;
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      new SuppressionManager(
+        [
+          { col: 2, row: 2 },
+          { col: 3, row: 3 },
+          { col: 4, row: 4 },
+          { col: 6, row: 6 },
+        ],
+        grid,
+      );
+      expect(warn).toHaveBeenCalledTimes(4);
+      // Invariant violations are warnings, not mutations — cell types
+      // stay as the designer placed them so the bug is visible in-game.
+      expect(grid.cells[2][2]).toBe(CellType.Entry);
+      expect(grid.cells[3][3]).toBe(CellType.Exit);
+      expect(grid.cells[4][4]).toBe(CellType.Blocked);
+      expect(grid.cells[6][6]).toBe(CellType.Tower);
+      warn.mockRestore();
+    });
+
+    it('silently skips pylons placed out of grid bounds (no warn, no crash)', () => {
+      const grid = makeGrid(10, 10);
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      // row out-of-range, then col out-of-range, then both.
+      expect(() => new SuppressionManager(
+        [
+          { col: 5, row: 99 },
+          { col: 99, row: 5 },
+          { col: 99, row: 99 },
+        ],
+        grid,
+      )).not.toThrow();
+      expect(warn).not.toHaveBeenCalled();
+      warn.mockRestore();
+    });
+
+    it('no-arg construction (no grid) skips the invariant entirely', () => {
+      // Headless construction without a grid — manager still works for
+      // suppression-logic tests that don't care about the invariant.
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const mgr = new SuppressionManager([{ col: 5, row: 5 }]);
+      expect(mgr.pylons).toHaveLength(1);
+      expect(warn).not.toHaveBeenCalled();
+      warn.mockRestore();
+    });
   });
 
   it('getActivePylonsInRangeOf includes only in-range active pylons', () => {

--- a/src/systems/suppression/SuppressionManager.ts
+++ b/src/systems/suppression/SuppressionManager.ts
@@ -23,23 +23,39 @@
 import { SuppressionPylon, type SuppressionPylonInit } from '../../entities/SuppressionPylon';
 import { gridX, gridY } from '../../config';
 import { CellType, type Grid } from '../Grid';
+import { type Trait, getTrait } from '../traits/Trait';
+
+/** Per-tower suppression state, carried on a `suppressible` trait when
+ *  a tower first comes under a pylon's influence. Lazy-attached by
+ *  SuppressionManager rather than declared on every tower at
+ *  construction (most towers in most missions never see a pylon). */
+export interface SuppressibleTraitState extends Trait {
+  id: 'suppressible';
+  /** Per-tick stress count. At `STRESS_THRESHOLD` the tower stalls
+   *  and the count resets. */
+  stress: number;
+  /** Last `lastFired` value the manager observed for this tower —
+   *  detects "this tower fired since the prior tick" without an
+   *  event bus subscription. -Infinity = never observed. */
+  seenLastFired: number;
+}
 
 /** Outcome of a `startChannelAt` call. Lets the caller render
  *  distinct feedback per failure mode without re-querying pylon
  *  state. */
 export type ChannelStartResult = 'started' | 'no_pylon' | 'already_muted' | 'already_channeling';
 
-/** Player tower contract — the manager only reads what it needs. */
+/** Player tower contract — the manager only reads what it needs.
+ *  Suppression state (stress, seenLastFired) lives on the
+ *  `suppressible` trait when present; lazy-attached by the manager
+ *  rather than declared on every tower at construction. */
 export interface SuppressibleTower {
   col: number;
   row: number;
   lastFired: number;
   _expired?: boolean;
-  _stress: number;
   _disabledRemaining: number;
-  /** Per-tower state the manager tracks — last `lastFired` value it
-   *  observed. -Infinity = never. Tower declares this default. */
-  _suppressionSeenLastFired: number;
+  traits: Trait[];
   /** Defenders / CPU towers (M10) shouldn't be suppressed by Voss's
    *  own pylons. ownerIndex 0 / undefined = player team. */
   ownerIndex?: number;
@@ -102,10 +118,9 @@ export class SuppressionManager {
 
   /** Per-frame: walk the tower list, bump stress on those that fired
    *  inside an active pylon, and trigger stalls at threshold. Per-
-   *  tower bookkeeping (`_suppressionSeenLastFired`) lives on Tower,
-   *  matching the codebase's "instance field" convention rather than
-   *  a side WeakMap. Also resolves any in-progress player channels
-   *  whose duration has elapsed. */
+   *  tower bookkeeping lives on the `suppressible` trait, lazily
+   *  attached on first need. Also resolves any in-progress player
+   *  channels whose duration has elapsed. */
   update(now: number, towers: SuppressibleTower[]): void {
     if (this.pylons.length === 0) return;
     this._resolveChannels(now);
@@ -115,17 +130,29 @@ export class SuppressionManager {
       // are immune to his own suppression.
       if ((tower.ownerIndex ?? 0) !== 0) continue;
 
-      if (tower.lastFired <= tower._suppressionSeenLastFired) continue;
-      tower._suppressionSeenLastFired = tower.lastFired;
+      const s = this._stateOf(tower);
+      if (tower.lastFired <= s.seenLastFired) continue;
+      s.seenLastFired = tower.lastFired;
 
       if (!this._inAnyActivePylon(tower, now)) continue;
 
-      tower._stress++;
-      if (tower._stress >= STRESS_THRESHOLD) {
-        tower._stress = 0;
+      s.stress++;
+      if (s.stress >= STRESS_THRESHOLD) {
+        s.stress = 0;
         tower._disabledRemaining = STALL_SECONDS;
       }
     }
+  }
+
+  /** Look up the tower's suppressible state, attaching the trait on
+   *  first call. Cheap when the trait is already present; one-time
+   *  allocation when first needed. */
+  private _stateOf(tower: SuppressibleTower): SuppressibleTraitState {
+    const existing = getTrait(tower.traits, 'suppressible') as SuppressibleTraitState | undefined;
+    if (existing) return existing;
+    const fresh: SuppressibleTraitState = { id: 'suppressible', stress: 0, seenLastFired: -Infinity };
+    tower.traits.push(fresh);
+    return fresh;
   }
 
   /** Mute the pylon at the given cell. Returns true if a pylon was

--- a/src/systems/suppression/SuppressionManager.ts
+++ b/src/systems/suppression/SuppressionManager.ts
@@ -22,6 +22,7 @@
 
 import { SuppressionPylon, type SuppressionPylonInit } from '../../entities/SuppressionPylon';
 import { gridX, gridY } from '../../config';
+import { CellType, type Grid } from '../Grid';
 
 /** Outcome of a `startChannelAt` call. Lets the caller render
  *  distinct feedback per failure mode without re-querying pylon
@@ -59,8 +60,44 @@ export const SIPHON_STACK_THRESHOLD = 5;
 export class SuppressionManager {
   readonly pylons: SuppressionPylon[];
 
-  constructor(pylons: SuppressionPylonInit[]) {
+  constructor(pylons: SuppressionPylonInit[], grid?: Grid) {
     this.pylons = pylons.map(p => new SuppressionPylon(p));
+    if (grid) this._validatePylonCells(grid);
+  }
+
+  /** Defensive runtime check: pylon cells must end up as `NoBuild`. The
+   *  click handler at the top of GameScene.handleClick assumes pylon
+   *  cells are not buildable (priority intercept for channel input);
+   *  the rest of the code assumes creeps don't spawn/exit on a pylon.
+   *
+   *  Auto-converts `Empty` cells to `NoBuild` (matching the old inline
+   *  logic in GameScene). For `Entry` / `Exit` / `Blocked` / `Tower`,
+   *  loudly warns: a designer or authoring tool placed a pylon where
+   *  the invariant doesn't hold and downstream behavior fragments.
+   *  Throwing was rejected — a broken pylon shouldn't break a whole
+   *  mission boot; the warning is enough to find this in the console.
+   *
+   *  Idempotent. Safe on out-of-bounds cells (skipped without warn —
+   *  out-of-bounds is already a separate map-validation bug). */
+  private _validatePylonCells(grid: Grid): void {
+    for (const pylon of this.pylons) {
+      const row = grid.cells[pylon.row];
+      if (!row) continue;
+      const cell = row[pylon.col];
+      if (cell === undefined) continue;
+      if (cell === CellType.Empty) {
+        row[pylon.col] = CellType.NoBuild;
+        continue;
+      }
+      if (cell === CellType.NoBuild) continue; // already correct
+      const name = CellType[cell] ?? `Unknown(${cell})`;
+      console.warn(
+        `[SuppressionManager] pylon at (${pylon.col}, ${pylon.row}) sits on ` +
+        `${name} — expected Empty or NoBuild. The click-handler invariant ` +
+        `(pylon-channel intercept assumes !buildable) may fragment. Fix ` +
+        `the map definition or authoring tool.`,
+      );
+    }
   }
 
   /** Per-frame: walk the tower list, bump stress on those that fired

--- a/src/systems/suppression/SuppressionRender.ts
+++ b/src/systems/suppression/SuppressionRender.ts
@@ -100,7 +100,8 @@ export class SuppressionRender {
     for (const t of towers) {
       if (t._expired) continue;
       if ((t.ownerIndex ?? 0) !== 0) continue;
-      const stress = t._stress;
+      const trait = t.traits.find(tr => tr.id === 'suppressible') as { stress?: number } | undefined;
+      const stress = trait?.stress ?? 0;
       if (stress <= 0) continue;
       // Intensity rises 0..1 across the 5 stress stacks.
       const intensity = Math.min(1, stress / 5);

--- a/src/systems/traits/TowerTraitHandlers.ts
+++ b/src/systems/traits/TowerTraitHandlers.ts
@@ -5,6 +5,7 @@ import { ChannelSystem } from '../channels/ChannelSystem';
 import {
   registerDelivery, registerDamageMod, registerFireRateMod,
   registerHitEffect, registerOnFire, registerTowerUpdate,
+  registerOverlayDraw, addOrRefreshTrait, removeTrait,
   Trait, HitContext, UpdateContext,
 } from './Trait';
 
@@ -1270,11 +1271,13 @@ registerTowerUpdate('conduit_link', (trait: Trait, tower: any, ctx: UpdateContex
     return { x: t.x, y: t.y, color: auraColors[auraTrait?.id] ?? 0xffcc44 };
   });
 
-  // Mark linked towers
+  // Mark linked towers via the `conduit_linked` trait. Each frame
+  // TowerManager strips the trait at the top of the reset pass; the
+  // conduit handler re-stamps it here. The trait's overlay-draw
+  // handler (registered below) paints the linked-indicator circle +
+  // faint line back to the conduit on the tower's render pass.
   for (const lt of linkedTowers) {
-    lt._linkedByConduit = true;
-    lt._conduitX = tower.x;
-    lt._conduitY = tower.y;
+    addOrRefreshTrait(lt.traits, { id: 'conduit_linked', srcX: tower.x, srcY: tower.y });
   }
 
   // Share auras between each pair of linked towers
@@ -1370,3 +1373,25 @@ function shareAura(auraTrait: Trait, fromTower: any, ctx: UpdateContext, conduit
     }
   }
 }
+
+// ─── conduit_linked overlay draw ────────────────────────────────
+// The aura-side cosmetic: a faint yellow circle around any tower
+// linked-by-conduit, plus a faint connecting line back to the
+// conduit source. Trait is re-stamped each frame by the conduit_link
+// handler above and stripped at TowerManager's reset pass; this
+// overlay handler runs after Tower.drawTower's base render via the
+// v2 resolveOverlayDraw pipeline.
+//
+// Replaces three `(this as any)` field reads on Tower (`_linkedByConduit`
+// / `_conduitX` / `_conduitY`) with typed trait state.
+registerOverlayDraw('conduit_linked', (trait, tower, graphics) => {
+  const s = TILE_SIZE * 0.35;
+  graphics.lineStyle(1, 0xffcc44, 0.5);
+  graphics.strokeCircle(tower.x, tower.y, s + 5);
+  const srcX = (trait as { srcX?: number }).srcX;
+  const srcY = (trait as { srcY?: number }).srcY;
+  if (typeof srcX === 'number' && typeof srcY === 'number') {
+    graphics.lineStyle(1, 0xffcc44, 0.15);
+    graphics.lineBetween(tower.x, tower.y, srcX, srcY);
+  }
+});

--- a/src/systems/traits/Trait.test.ts
+++ b/src/systems/traits/Trait.test.ts
@@ -1,0 +1,146 @@
+/**
+ * Tests for the v2 Tower-side trait pipeline extensions:
+ * damage veto, damage modifier, onTakeDamage, onKill, onSpawn,
+ * onDespawn, overlayDraw.
+ *
+ * These resolvers are consumed by Tower.takeDamage and Tower.drawTower
+ * (commit 3+ in the refactor). Existing hit-side resolvers
+ * (delivery / damageModifier / fireRate / etc.) are unchanged and
+ * already exercised by existing tests indirectly.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  registerDamageVeto,
+  registerDamageModifier,
+  registerOnTakeDamage,
+  registerOnKill,
+  registerOnSpawn,
+  registerOnDespawn,
+  registerOverlayDraw,
+  resolveDamageVeto,
+  resolveTowerDamageModifiers,
+  resolveOnTakeDamage,
+  resolveOnKill,
+  resolveOnSpawn,
+  resolveOnDespawn,
+  resolveOverlayDraw,
+  type Trait,
+} from './Trait';
+
+// The trait registries are module-level singletons — re-registering
+// over the same id replaces the handler, so each test uses a unique
+// prefix to avoid bleeding across describes.
+
+describe('Trait pipeline v2 — damage veto', () => {
+  it('returns false when no trait registers a veto', () => {
+    const traits: Trait[] = [{ id: 'veto_test_none' }];
+    expect(resolveDamageVeto(traits, 100, 'hero', {})).toBe(false);
+  });
+
+  it('OR semantics: any handler returning true vetoes', () => {
+    registerDamageVeto('veto_test_no', () => false);
+    registerDamageVeto('veto_test_yes', () => true);
+    const traits: Trait[] = [{ id: 'veto_test_no' }, { id: 'veto_test_yes' }];
+    expect(resolveDamageVeto(traits, 100, 'hero', {})).toBe(true);
+  });
+
+  it('short-circuits on first true (later handlers do not run)', () => {
+    const later = vi.fn(() => false);
+    registerDamageVeto('veto_first_yes', () => true);
+    registerDamageVeto('veto_later', later);
+    const traits: Trait[] = [{ id: 'veto_first_yes' }, { id: 'veto_later' }];
+    resolveDamageVeto(traits, 100, 'hero', {});
+    expect(later).not.toHaveBeenCalled();
+  });
+
+  it('passes amount, source, and tower through to the handler', () => {
+    const fn = vi.fn(() => false);
+    registerDamageVeto('veto_args', fn);
+    const tower = { id: 'mock-tower' };
+    resolveDamageVeto([{ id: 'veto_args' }], 42, 'raider', tower);
+    expect(fn).toHaveBeenCalledWith({ id: 'veto_args' }, 42, 'raider', tower);
+  });
+});
+
+describe('Trait pipeline v2 — damage modifier chain', () => {
+  it('returns the input amount when no modifier traits match', () => {
+    expect(resolveTowerDamageModifiers([{ id: 'mod_test_none' }], 100, 'hero', {})).toBe(100);
+  });
+
+  it('chains modifiers in trait-list order', () => {
+    registerDamageModifier('mod_half', (_t, a) => a / 2);
+    registerDamageModifier('mod_plus_10', (_t, a) => a + 10);
+    // [half, plus_10]: 100 → 50 → 60
+    expect(resolveTowerDamageModifiers(
+      [{ id: 'mod_half' }, { id: 'mod_plus_10' }], 100, 'hero', {},
+    )).toBe(60);
+    // [plus_10, half]: 100 → 110 → 55
+    expect(resolveTowerDamageModifiers(
+      [{ id: 'mod_plus_10' }, { id: 'mod_half' }], 100, 'hero', {},
+    )).toBe(55);
+  });
+});
+
+describe('Trait pipeline v2 — onTakeDamage / onKill side-effects', () => {
+  beforeEach(() => {
+    // Re-register fresh spies each test so call counts don't leak.
+  });
+
+  it('onTakeDamage fires every matching handler', () => {
+    const a = vi.fn();
+    const b = vi.fn();
+    registerOnTakeDamage('otd_a', a);
+    registerOnTakeDamage('otd_b', b);
+    resolveOnTakeDamage([{ id: 'otd_a' }, { id: 'otd_b' }], 25, 'hero', {});
+    expect(a).toHaveBeenCalledOnce();
+    expect(b).toHaveBeenCalledOnce();
+  });
+
+  it('onKill fires once per matching trait', () => {
+    const fn = vi.fn();
+    registerOnKill('kill_test', fn);
+    resolveOnKill([{ id: 'kill_test' }], 'send', {});
+    expect(fn).toHaveBeenCalledExactlyOnceWith({ id: 'kill_test' }, 'send', {});
+  });
+
+  it('resolvers skip traits with no registered handler', () => {
+    // Should be a no-op (no throw, no call) when the trait id isn't
+    // registered anywhere — happens routinely for hit-time-only traits.
+    expect(() => resolveOnTakeDamage([{ id: 'no_handler' }], 10, 'hero', {})).not.toThrow();
+    expect(() => resolveOnKill([{ id: 'no_handler' }], 'hero', {})).not.toThrow();
+  });
+});
+
+describe('Trait pipeline v2 — spawn / despawn lifecycle', () => {
+  it('onSpawn + onDespawn fire each matching handler exactly once', () => {
+    const spawn = vi.fn();
+    const despawn = vi.fn();
+    registerOnSpawn('lc_test', spawn);
+    registerOnDespawn('lc_test', despawn);
+    const tower = { id: 'tower-x' };
+    resolveOnSpawn([{ id: 'lc_test' }], tower);
+    resolveOnDespawn([{ id: 'lc_test' }], tower);
+    expect(spawn).toHaveBeenCalledExactlyOnceWith({ id: 'lc_test' }, tower);
+    expect(despawn).toHaveBeenCalledExactlyOnceWith({ id: 'lc_test' }, tower);
+  });
+});
+
+describe('Trait pipeline v2 — overlayDraw', () => {
+  it('runs each registered overlay drawer in trait order', () => {
+    const order: string[] = [];
+    registerOverlayDraw('ov_first', () => order.push('first'));
+    registerOverlayDraw('ov_second', () => order.push('second'));
+    resolveOverlayDraw([{ id: 'ov_first' }, { id: 'ov_second' }], {}, {}, {});
+    expect(order).toEqual(['first', 'second']);
+  });
+
+  it('passes tower / graphics / scene through unchanged', () => {
+    const fn = vi.fn();
+    registerOverlayDraw('ov_args', fn);
+    const tower = { id: 't' };
+    const graphics = { id: 'g' };
+    const scene = { id: 's' };
+    resolveOverlayDraw([{ id: 'ov_args' }], tower, graphics, scene);
+    expect(fn).toHaveBeenCalledWith({ id: 'ov_args' }, tower, graphics, scene);
+  });
+});

--- a/src/systems/traits/Trait.ts
+++ b/src/systems/traits/Trait.ts
@@ -1,5 +1,6 @@
 import { ArmorType, DamageType } from '../../data/CreepTypes';
 import { calculateDamage } from '../DamageCalculator';
+import type { DamageSource } from '../../entities/Damageable';
 
 // --- Core Types ---
 
@@ -79,6 +80,30 @@ type CreepDamageFn = (trait: Trait, damage: number) => number;
 type CreepUpdateFn = (trait: Trait, creep: any, delta: number, nearbyCreeps: any[]) => void;
 type CreepDrawFn = (trait: Trait, creep: any, graphics: any) => void;
 
+// --- Lifecycle / damage / render pipeline (Tower-side, v2 refactor) ---
+
+/** Veto = "this damage should not apply at all" (e.g. M10 throne is
+ *  invulnerable while generators alive, shield-bubble absorbs the hit).
+ *  OR semantics: any handler returning true vetoes the damage. */
+type DamageVetoFn = (trait: Trait, amount: number, source: DamageSource, tower: any) => boolean;
+/** Modifier = chained multiplier/transform on the incoming amount
+ *  (resists, vulnerability buffs, partial absorb). Run after veto. */
+type DamageModifierFn = (trait: Trait, amount: number, source: DamageSource, tower: any) => number;
+/** onTakeDamage = side-effect after damage applied (animations,
+ *  events, retaliation flagging). Cannot change the amount. */
+type OnTakeDamageFn = (trait: Trait, amount: number, source: DamageSource, tower: any) => void;
+/** onKill = killing-blow hook. Fires after hp <= 0 + _expired set,
+ *  before the next-frame cleanup. */
+type OnKillFn = (trait: Trait, source: DamageSource, tower: any) => void;
+/** onSpawn / onDespawn — lifecycle hooks. Fire on construction
+ *  (after trait list is materialised) and at cleanup time. */
+type OnSpawnFn = (trait: Trait, tower: any) => void;
+type OnDespawnFn = (trait: Trait, tower: any) => void;
+/** Overlay draw — each trait can paint on top of the base tower
+ *  render. Replaces drawTower's hard-coded campaign-specific
+ *  conditionals (golden ult border, conduit link arc, etc.). */
+type OverlayDrawFn = (trait: Trait, tower: any, graphics: any, scene: any) => void;
+
 // --- Registry ---
 
 const deliveryReg = new Map<string, DeliveryFn>();
@@ -90,6 +115,13 @@ const towerUpdateReg = new Map<string, TowerUpdateFn>();
 const creepDamageReg = new Map<string, CreepDamageFn>();
 const creepUpdateReg = new Map<string, CreepUpdateFn>();
 const creepDrawReg = new Map<string, CreepDrawFn>();
+const damageVetoReg = new Map<string, DamageVetoFn>();
+const damageModifierReg = new Map<string, DamageModifierFn>();
+const onTakeDamageReg = new Map<string, OnTakeDamageFn>();
+const onKillReg = new Map<string, OnKillFn>();
+const onSpawnReg = new Map<string, OnSpawnFn>();
+const onDespawnReg = new Map<string, OnDespawnFn>();
+const overlayDrawReg = new Map<string, OverlayDrawFn>();
 
 // --- Registration ---
 
@@ -102,6 +134,13 @@ export function registerTowerUpdate(id: string, fn: TowerUpdateFn) { towerUpdate
 export function registerCreepDamage(id: string, fn: CreepDamageFn) { creepDamageReg.set(id, fn); }
 export function registerCreepUpdate(id: string, fn: CreepUpdateFn) { creepUpdateReg.set(id, fn); }
 export function registerCreepDraw(id: string, fn: CreepDrawFn) { creepDrawReg.set(id, fn); }
+export function registerDamageVeto(id: string, fn: DamageVetoFn) { damageVetoReg.set(id, fn); }
+export function registerDamageModifier(id: string, fn: DamageModifierFn) { damageModifierReg.set(id, fn); }
+export function registerOnTakeDamage(id: string, fn: OnTakeDamageFn) { onTakeDamageReg.set(id, fn); }
+export function registerOnKill(id: string, fn: OnKillFn) { onKillReg.set(id, fn); }
+export function registerOnSpawn(id: string, fn: OnSpawnFn) { onSpawnReg.set(id, fn); }
+export function registerOnDespawn(id: string, fn: OnDespawnFn) { onDespawnReg.set(id, fn); }
+export function registerOverlayDraw(id: string, fn: OverlayDrawFn) { overlayDrawReg.set(id, fn); }
 
 // --- Resolution Pipeline ---
 
@@ -201,6 +240,78 @@ export function resolveCreepDraw(traits: Trait[], creep: any, graphics: any): vo
     if (fn) {
       fn(trait, creep, graphics);
     }
+  }
+}
+
+// --- Tower lifecycle / damage / render resolvers (v2) ---
+
+/** Run the damage-veto pipeline. OR semantics: any handler returning
+ *  true vetoes the damage entirely. Caller short-circuits on true. */
+export function resolveDamageVeto(traits: Trait[], amount: number, source: DamageSource, tower: any): boolean {
+  for (const trait of traits) {
+    const fn = damageVetoReg.get(trait.id);
+    if (fn && fn(trait, amount, source, tower)) return true;
+  }
+  return false;
+}
+
+/** Run the damage-modifier chain on a Tower-side hit. Each handler
+ *  takes the current amount and returns the new amount; order is
+ *  trait-list order. Run AFTER veto, BEFORE applying to hp. */
+export function resolveTowerDamageModifiers(traits: Trait[], amount: number, source: DamageSource, tower: any): number {
+  let a = amount;
+  for (const trait of traits) {
+    const fn = damageModifierReg.get(trait.id);
+    if (fn) a = fn(trait, a, source, tower);
+  }
+  return a;
+}
+
+/** Side-effect hooks after damage applied (animations, retaliation
+ *  flagging). Cannot change the amount; runs even on 0-amount hits
+ *  if any trait wants to react to "I was targeted but absorbed." */
+export function resolveOnTakeDamage(traits: Trait[], amount: number, source: DamageSource, tower: any): void {
+  for (const trait of traits) {
+    const fn = onTakeDamageReg.get(trait.id);
+    if (fn) fn(trait, amount, source, tower);
+  }
+}
+
+/** Killing-blow hook. Fires once, after hp <= 0 and _expired = true. */
+export function resolveOnKill(traits: Trait[], source: DamageSource, tower: any): void {
+  for (const trait of traits) {
+    const fn = onKillReg.get(trait.id);
+    if (fn) fn(trait, source, tower);
+  }
+}
+
+/** Lifecycle: tower constructed and trait list materialised. Run
+ *  once at the end of Tower's constructor. */
+export function resolveOnSpawn(traits: Trait[], tower: any): void {
+  for (const trait of traits) {
+    const fn = onSpawnReg.get(trait.id);
+    if (fn) fn(trait, tower);
+  }
+}
+
+/** Lifecycle: tower about to be cleaned up (next-frame after _expired).
+ *  Run before grid removal so handlers can read final state. */
+export function resolveOnDespawn(traits: Trait[], tower: any): void {
+  for (const trait of traits) {
+    const fn = onDespawnReg.get(trait.id);
+    if (fn) fn(trait, tower);
+  }
+}
+
+/** Run each trait's overlay-draw handler after the base tower render.
+ *  Replaces drawTower's campaign-specific conditionals — each campaign
+ *  registers its own overlay (golden ult border, conduit link, hack
+ *  glow, etc.) and drawTower just iterates. Order is trait-list order;
+ *  Phaser graphics compositing makes overlapping draws additive. */
+export function resolveOverlayDraw(traits: Trait[], tower: any, graphics: any, scene: any): void {
+  for (const trait of traits) {
+    const fn = overlayDrawReg.get(trait.id);
+    if (fn) fn(trait, tower, graphics, scene);
   }
 }
 


### PR DESCRIPTION
## Summary

Started as a small cleanup pass; the larger Tower.ts bag-of-flags refactor (v2 plan) will land on this same branch in follow-up commits.

### Commit 1: Suppression pylon-cell invariant

Moves the pylon-on-noBuild assumption out of GameScene's inline stamp loop into `SuppressionManager`'s constructor. Auto-converts Empty → NoBuild (preserves old behavior), warns loudly when a pylon sits on Entry/Exit/Blocked/Tower (cell *not* mutated — the bug must be visible). Silently skips out-of-bounds. Five new unit tests. 626 → 631 unit tests, all pass.

### Coming next (same branch)

Tower.ts bag-of-flags v2 — trait pipeline + damage pipeline + render-hooks registry. Plan lives in memory at `project_tower_refactor.md`; will commit a re-derived plan to `docs/` before the refactor commits land for review visibility.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] Full unit suite: 631 / 631
- [x] Full unit suite stays green after each bag-of-flags commit
- [x] M10 e2e (e2e/m10-overthrow.spec.ts) stays green throughout

## Note on branch name

`ah/cleanup/sprite-location-pylon-invariant` is now a misnomer — sprite-location turned out to be a non-issue (the file at the repo root matches the project convention; my review was wrong). Keeping the name for push-history simplicity; the PR title is the source of truth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)