### PR TITLE
Implement bespoke map layouts for Greenward missions

### DIFF
--- a/docs/greenward-bespoke-maps-prd.md
+++ b/docs/greenward-bespoke-maps-prd.md
@@ -1,0 +1,165 @@
+# PRD — Greenward Bespoke Map Layouts
+
+**Status:** Active. Branch: `ah/feature/greenward-bespoke-maps` (off `ah/feature/greenward-campaign`; rebases to develop once PR #74 merges).
+**Owner:** Alex
+**Trigger:** PR #74 shipped the 10 Greenward missions with theme-overridden plains-template maps. Each mission has a Consecration ruin layout that *would* work on a bespoke map, but the actual map shape (paths, blocked cells, entries / exits) is currently `plains` cloned 10×. Each map needs a hand-authored layout matching its mission's narrative beats — the wayshrine at the road's end, the crossroads at the marsh, the wedding pavilion centred on the altar, the three-section cathedral.
+
+---
+
+## Goal
+
+Each of the ten Greenward missions gets a hand-authored map that matches its narrative + supports its Consecration ruin layout. After this PR, each map JSON in `src/data/maps/` (or inline in `Maps.ts`'s MAPS Record) is a deliberate design that reads as the place the mission's story describes.
+
+## Non-goals
+
+- New large-structure sprites (e.g. an actual wayshrine prop) — the existing terrain palettes + ruin-tile overlays carry the visual load.
+- Changing Consecration ruin coordinates already set in `greenward.ts` mission overrides — maps are designed *around* those cells.
+- Map editor (`/editor.html`) feature additions — we use the existing editor as-is.
+- Balance tuning of wave compositions per map — that's PR D (balance pass).
+
+## Authoring workflow
+
+Each map is authored via `/editor.html` and exported as JSON saved to `src/data/maps/greenward/<id>.json`. The existing JSON-map loader (used by gauntlet maps) handles deserialization. Per-map effort estimate appears in the commit-by-commit section below.
+
+**Per-map deliverables (each):**
+
+1. JSON file at `src/data/maps/greenward/<id>.json`.
+2. `Maps.ts` MAPS entry switches from the template clone to load via `loadGreenwardMap(id)` helper.
+3. One unit test that asserts: entries / exits exist, the mission's Consecration ruin cells are on `noBuild` (not `Blocked`), pathfind from entry to exit succeeds.
+4. (Optional) screenshot for the PR description.
+
+## Design guidelines per map
+
+### M1 — `greenward_boundary` (Boundary Stones)
+- **Reads as:** a road leaving the Wildwood at sunrise. Forest at the west edge, open road heading east to a stone wayshrine.
+- **Entries:** 1 at east edge (creeps approaching from the south kingdoms toward the player's Wildwood).
+- **Exits:** 1 at west edge (Wildwood).
+- **Ruin cell:** wayshrine at (18, 13). NoBuild.
+- **Blocked cells:** sparse forest on the north + south margins to channel a single road.
+- **Tutorial layout:** very simple path, lots of buildable space around the shrine.
+- **Effort:** ~20 min.
+
+### M2 — `greenward_meadow` (Salt Meadow)
+- **Reads as:** open saline field, three small cairns. Sparse, exposed.
+- **Entries:** 2 (north + south edges, suggesting Inheritors creeping in from both flanks).
+- **Exits:** 1 west.
+- **Ruin cells:** cairn_north (14, 8), cairn_south (14, 18), barrow (22, 13). All NoBuild.
+- **Blocked cells:** none or minimal — the meadow is OPEN by design (salt killed everything).
+- **Restriction:** Bramble + Root only, so the maze must form around minimal blockers.
+- **Effort:** ~30 min.
+
+### M3 — `greenward_eadwin` (Eadwin)
+- **Reads as:** an inn-village. Buildings at the centre, square in front, inn on the north side.
+- **Entries:** 1 east.
+- **Exits:** 1 west.
+- **Ruin cells:** inn_hearth (18, 10) NoBuild, village_square (14, 15) NoBuild.
+- **Blocked cells:** building footprints (rectangular clusters at NE for the inn, central E-W for shop fronts).
+- **Path:** weaves between buildings, brushing both ruin cells.
+- **Effort:** ~45 min.
+
+### M4 — `greenward_crows` (Road of Crows)
+- **Reads as:** marsh crossroads. Two crossing paths.
+- **Entries:** 2 (north + south).
+- **Exits:** 2 (east + west). Crossroads where they meet.
+- **Ruin cells:** crossroads (18, 13) Mercy — Cethric sits here, isolated from any splash placement; eastern_road (26, 13) Ceremony.
+- **Blocked cells:** marsh patches (water-themed terrain already handles palette) at irregular intervals; the Cethric cell sits in a "safe pocket" surrounded by NoBuild buffer ring so even close splash placement has to be intentional.
+- **Effort:** ~45 min.
+
+### M5 — `greenward_river` (Dry River)
+- **Reads as:** river running east-to-west, drying as the mission progresses (palette animation already in place via the `water` theme).
+- **Entries:** 1 west (river exits to the Wildwood).
+- **Exits:** 1 east (toward the headwater).
+- **Ruin cells:** headwater (30, 13) Ceremony, river_west (8, 13) + river_east (18, 13) Siege.
+- **Blocked cells:** river banks at top + bottom create a forced linear path.
+- **Speedrun:** path is short and direct; the time pressure is the mechanic.
+- **Effort:** ~30 min.
+
+### M6 — `greenward_tarrenford` (Tarrenford)
+- **Reads as:** a living village. Chapel, well, wheat field. Civilians present.
+- **Entries:** 1 north.
+- **Exits:** 1 south.
+- **Ruin cells:** chapel (14, 8) Ceremony, well (18, 13) Ceremony, wheat_field (22, 18) Ceremony.
+- **Blocked cells:** chapel footprint (NE 3×3 cluster), well (single tile), wheat-field rows (south region).
+- **Path:** winds through the village, passing each ruin in sequence so the player can plant Blossoms for all three over the mission duration.
+- **Effort:** ~60 min.
+- **Note:** Civilian creep paths intersect the main wave path. Per-creep type already pinned to non-killable.
+
+### M7 — `greenward_weddingstone` (Wedding-Stone)
+- **Reads as:** frozen wedding pavilion. Altar in the centre, party arrayed around it.
+- **Entries:** 2 (east + west, the party approaches from both sides).
+- **Exits:** 1 north (the cleared path the bride was meant to walk).
+- **Ruin cells:** altar (18, 10) Mercy, pavilion (18, 18) Siege. NoBuild.
+- **Blocked cells:** pavilion pillars in a circular arrangement, wedding-feast tables at the south edge.
+- **Frugal layout:** restricted tower count + reserves squeeze means tight choke points matter.
+- **Effort:** ~45 min.
+
+### M8 — `greenward_court` (Stillborn Court)
+- **Reads as:** courtyard with three doors. Throne dais at the back. Inheritor host enters from the three doors.
+- **Entries:** 3 (three doors at the south edge — boss-rush archetype's signature shape).
+- **Exits:** 1 north (toward Caer Lythen).
+- **Ruin cells:** court_grounds (14, 13) Siege, the_child (22, 13) Mercy.
+- **Blocked cells:** pillared court geometry. Child's path circumnavigates without intersecting splash zones.
+- **Boss-rush:** each door spawns one of the three boss types in rotation (Knight / Herald / Child).
+- **Effort:** ~60 min.
+
+### M9 — `greenward_lastgarden` (Last Garden)
+- **Reads as:** the Inheritor watchtower on the road to Caer Lythen. Player sends creeps from the east toward the watchtower at the west.
+- **Entries:** 1 east (Marra sends from here).
+- **Exits:** 1 west (the watchtower).
+- **Ruin cell:** watchtower (6, 13) Siege.
+- **Blocked cells:** Inheritor defender tower placements pre-positioned (the M9 attacker archetype reads these from `mapDef.preplacedTowers`).
+- **Attacker layout:** reverses player path direction; the standard attacker_assault map shape adapted.
+- **Effort:** ~75 min.
+
+### M10 — `greenward_cathedral` (Caer Lythen, the Sun-Cathedral)
+- **Reads as:** three distinct zones — Courtyard (west) / Nave (centre) / Throne (east). Cathedral architecture.
+- **Entries:** wave-script driven; each setpiece spawns its own waves.
+- **Exits:** 1 west during Courtyard; replaced by 1 east for Throne defense (or static fortress-style entry/exit pattern with phase-specific blockers).
+- **Ruin cells:** courtyard (6, 13) Siege, nave (18, 13) Mercy (runtime-mutated), throne (30, 13) Siege.
+- **Blocked cells:** cathedral nave pillars in the centre, throne dais at east. Three distinct visual zones.
+- **Map size:** larger than standard — 1.5× width if the engine supports it; otherwise dense use of the standard 36×26 grid with three setpiece sub-zones.
+- **Effort:** ~120 min.
+
+## Commits
+
+Batched by Act for review tractability. Each commit ships its act's maps + Maps.ts integration + tests.
+
+### Commit 1 — `Bespoke maps: Act I (M1-M3)`
+Maps for `greenward_boundary` / `greenward_meadow` / `greenward_eadwin`. Effort: ~1.75 hrs of authoring + 30 min integration / tests.
+
+### Commit 2 — `Bespoke maps: Act II (M4-M7)`
+Maps for `greenward_crows` / `greenward_river` / `greenward_tarrenford` / `greenward_weddingstone`. Effort: ~3 hrs authoring + 45 min integration / tests.
+
+### Commit 3 — `Bespoke maps: Act III pre-finale (M8-M9)`
+Maps for `greenward_court` / `greenward_lastgarden`. Effort: ~2.25 hrs authoring + 30 min integration / tests.
+
+### Commit 4 — `Bespoke maps: M10 Caer Lythen three-section cathedral`
+Map for `greenward_cathedral`. Most ambitious single map in the project. Effort: ~2 hrs authoring + 30 min integration / tests.
+
+## Acceptance per commit
+
+- `npx tsc --noEmit` clean.
+- Full unit suite green.
+- Per-map test: entries / exits present, ruin cells NoBuild, pathfind from entry to exit succeeds.
+- Existing `e2e/greenward-smoke.spec.ts` still passes (the smoke spec doesn't care about map layout, just that M1 + M10 boot).
+- (Manual gate) Each map opens cleanly in the dev server + plays at least its first wave without lockup.
+
+## Risks
+
+| Risk | Severity | Mitigation |
+|---|---|---|
+| Bespoke map design takes longer than estimated | High | Effort estimates are upper-bound — first pass via the editor is what matters. Iterate post-merge. |
+| Multi-entry / multi-exit maps confuse the existing pathfind | Medium | M2 (2-entry), M4 (2-entry / 2-exit), M7 (2-entry), M8 (3-entry) — verify against existing multi-entry maps (`base_arena`) for pattern. |
+| Ruin cell coordinates conflict with the new layouts | Medium | Author maps around the existing Consecration coords from `greenward.ts`. If a coord is unworkable, update both files in the same commit. |
+| M10 three-section layout pushes the engine's grid limits | High | Fallback: dense 36×26 with three sub-zones marked by Blocked-cell barriers. The 1.5× width is aspirational, not required. |
+
+## Safety nets
+
+- Existing `tutorial` and `plains` maps are the simplest layouts; use as scaffolding pattern.
+- `base_arena` is the existing reference for multi-entry maps.
+- `attacker_assault` is the reference for M9's reverse-path attacker map.
+- `arcane_throne_finale` + `mech_throne_finale` are the references for M10's three-zone setpiece layout.
+
+## Effort estimate
+
+4 commits, ~10-12 hrs end-to-end with focused work — heavily front-loaded on the editor side rather than code. The author of this PR is doing map design, not engineering.

--- a/src/data/Maps.ts
+++ b/src/data/Maps.ts
@@ -248,6 +248,57 @@ function greenwardEadwinRuins(): Pos[] {
   ];
 }
 
+function greenwardMarshPatches(): Pos[] {
+  // Marsh patches at irregular intervals — water-themed.
+  // Critically: leave a "safe pocket" buffer around Cethric (col 18,
+  // row 13) so splash placement nearby is intentional not accidental.
+  const ps: Pos[] = [];
+  // North-west marsh
+  for (let c = 4; c <= 10; c += 2) for (let r = 4; r <= 8; r += 2) ps.push({ col: c, row: r });
+  // South-east marsh
+  for (let c = 24; c <= 30; c += 2) for (let r = 16; r <= 20; r += 2) ps.push({ col: c, row: r });
+  // South-west marsh
+  for (let c = 4; c <= 8; c += 2) for (let r = 18; r <= 22; r += 2) ps.push({ col: c, row: r });
+  // Filter out anything within 2 cells of Cethric (Chebyshev) — keep the safe pocket.
+  return ps.filter(p => Math.max(Math.abs(p.col - 18), Math.abs(p.row - 13)) > 2);
+}
+
+function greenwardRiverBanks(): Pos[] {
+  // Linear river: top + bottom banks forming a 5-row corridor in
+  // the middle. The river itself isn't blocked — creeps walk it.
+  const ps: Pos[] = [];
+  for (let c = 0; c < GRID_COLS; c++) {
+    ps.push({ col: c, row: 9 });
+    ps.push({ col: c, row: 17 });
+  }
+  return ps;
+}
+
+function greenwardTarrenfordBuildings(): Pos[] {
+  // Chapel footprint NE (3x3), well center, wheat field rows south.
+  const ps: Pos[] = [];
+  // Chapel
+  for (let c = 12; c <= 16; c++) for (let r = 6; r <= 9; r++) ps.push({ col: c, row: r });
+  // Wheat field rows
+  for (let c = 18; c <= 28; c += 2) ps.push({ col: c, row: 19 });
+  for (let c = 18; c <= 28; c += 2) ps.push({ col: c, row: 21 });
+  return ps;
+}
+
+function greenwardWeddingPavilion(): Pos[] {
+  // Circular pillar arrangement around the altar at (18, 10).
+  const ps: Pos[] = [];
+  const pillars: Pos[] = [
+    { col: 14, row: 8 },  { col: 22, row: 8 },
+    { col: 12, row: 11 }, { col: 24, row: 11 },
+    { col: 14, row: 14 }, { col: 22, row: 14 },
+  ];
+  ps.push(...pillars);
+  // Feast tables at south edge.
+  for (let c = 14; c <= 22; c += 2) ps.push({ col: c, row: 21 });
+  return ps;
+}
+
 export const MAPS: Record<MapId, MapDefinition> = {
   plains: {
     id: 'plains',
@@ -991,10 +1042,86 @@ export const MAPS: Record<MapId, MapDefinition> = {
     // The inn-hearth + village square ruins are noBuild.
     noBuild: greenwardEadwinRuins(),
   },
-  greenward_crows:        { ...MAPS_PLAINS_TEMPLATE, id: 'greenward_crows',        name: 'Road of Crows',   theme: 'water' },
-  greenward_river:        { ...MAPS_PLAINS_TEMPLATE, id: 'greenward_river',        name: 'Dry River',       theme: 'water' },
-  greenward_tarrenford:   { ...MAPS_PLAINS_TEMPLATE, id: 'greenward_tarrenford',   name: 'Tarrenford',      theme: 'forest' },
-  greenward_weddingstone: { ...MAPS_PLAINS_TEMPLATE, id: 'greenward_weddingstone', name: 'Wedding-Stone',   theme: 'stone' },
+  // Act II — Salt Roads. Marsh crossroads, dying river, still-alive
+  // Tarrenford, frozen wedding pavilion.
+
+  greenward_crows: {
+    id: 'greenward_crows',
+    name: 'The Road of Crows',
+    description: 'Marsh crossroads. Cethric sits cross-legged at the meeting of paths.',
+    theme: 'water',
+    // Multi-path crossroads — two entries (N+S) and two exits (E+W).
+    entries: [
+      { col: 17, row: 0 },
+      { col: 17, row: GRID_ROWS - 1 },
+    ],
+    exits: [
+      { col: 0,             row: 13 },
+      { col: GRID_COLS - 1, row: 13 },
+    ],
+    blocked: greenwardMarshPatches(),
+    // crossroads (Mercy — Cethric) + eastern_road (Ceremony)
+    noBuild: [
+      { col: 18, row: 13 }, // crossroads
+      { col: 26, row: 13 }, // eastern_road
+    ],
+  },
+
+  greenward_river: {
+    id: 'greenward_river',
+    name: 'The Dry River',
+    description: 'A river going salt as Marra watches. The headwater is upstream.',
+    theme: 'water',
+    // Linear east-to-west river. The headwater is east; creeps
+    // approach from the east, exit to the west toward the Wildwood.
+    entries: [{ col: GRID_COLS - 1, row: 13 }],
+    exits:   [{ col: 0,             row: 13 }],
+    blocked: greenwardRiverBanks(),
+    // headwater (Ceremony at east) + river_west + river_east (Siege).
+    noBuild: [
+      { col: 30, row: 13 }, // headwater
+      { col: 8,  row: 13 }, // river_west
+      { col: 18, row: 13 }, // river_east
+    ],
+  },
+
+  greenward_tarrenford: {
+    id: 'greenward_tarrenford',
+    name: 'Tarrenford',
+    description: 'A village still alive. Chapel, well, wheat. Forty-seven people.',
+    theme: 'forest',
+    // North entry, south exit — Inheritors approach the village from
+    // above; civilians cross the path in both directions.
+    entries: [{ col: MID_COL, row: 0 }],
+    exits:   [{ col: MID_COL, row: GRID_ROWS - 1 }],
+    blocked: greenwardTarrenfordBuildings(),
+    // chapel + well + wheat_field — three Ceremony ruins.
+    noBuild: [
+      { col: 14, row: 8 },  // chapel
+      { col: 18, row: 13 }, // well
+      { col: 22, row: 18 }, // wheat_field
+    ],
+  },
+
+  greenward_weddingstone: {
+    id: 'greenward_weddingstone',
+    name: 'Wedding-Stone',
+    description: 'A wedding turned to stone. The bride still stands at the altar.',
+    theme: 'stone',
+    // Two entries (E+W, the wedding party approaches from both
+    // sides) + one north exit (the cleared path the bride was
+    // meant to walk).
+    entries: [
+      { col: 0,             row: 13 },
+      { col: GRID_COLS - 1, row: 13 },
+    ],
+    exits: [{ col: MID_COL, row: 0 }],
+    blocked: greenwardWeddingPavilion(),
+    noBuild: [
+      { col: 18, row: 10 }, // altar (Mercy)
+      { col: 18, row: 18 }, // pavilion (Siege)
+    ],
+  },
   greenward_court:        { ...MAPS_PLAINS_TEMPLATE, id: 'greenward_court',        name: 'Stillborn Court', theme: 'stone' },
   greenward_lastgarden:   { ...MAPS_PLAINS_TEMPLATE, id: 'greenward_lastgarden',   name: 'Last Garden',     theme: 'mountain' },
   greenward_cathedral:    { ...MAPS_PLAINS_TEMPLATE, id: 'greenward_cathedral',    name: 'Caer Lythen',     theme: 'arcane_crystal' },

--- a/src/data/Maps.ts
+++ b/src/data/Maps.ts
@@ -186,9 +186,9 @@ function circle(cx: number, cy: number, radius: number): Pos[] {
 }
 
 // Reusable template used by Greenward map stubs at the bottom of
-// MAPS. Cloned with `...MAPS_PLAINS_TEMPLATE` so per-mission commits
-// (10-19 in the Greenward execution plan) can replace each entry
-// independently without touching this template.
+// MAPS. Cloned with `...MAPS_PLAINS_TEMPLATE` so each Greenward map
+// entry can be authored independently. Maps not yet authored fall
+// back to this template.
 const MAPS_PLAINS_TEMPLATE: Omit<MapDefinition, 'id' | 'name'> = {
   description: 'Greenward — stub map. Replaced by per-mission commit.',
   theme: 'forest',
@@ -197,6 +197,56 @@ const MAPS_PLAINS_TEMPLATE: Omit<MapDefinition, 'id' | 'name'> = {
   blocked: [],
   noBuild: [],
 };
+
+// ─── Greenward map helpers ─────────────────────────────────────
+// Reusable helpers for hand-authoring Greenward maps without an
+// editor. Each returns Pos[] suitable for blocked / noBuild fields.
+
+function greenwardForestEdge(): Pos[] {
+  // Sparse forest along the north + south edges of M1 — narrows
+  // the player's view into a single road corridor through the
+  // open middle band.
+  const ps: Pos[] = [];
+  for (let c = 0; c < GRID_COLS; c++) {
+    // Sparse top / bottom rows
+    if (c % 3 === 0) {
+      ps.push({ col: c, row: 1 });
+      ps.push({ col: c, row: GRID_ROWS - 2 });
+    }
+  }
+  return ps;
+}
+
+function greenwardSaltCairns(): Pos[] {
+  // The two cairn cells are noBuild — the player can't drop a tower
+  // ON the shepherd's marker but mazes around it.
+  return [
+    { col: 14, row: 8 },
+    { col: 14, row: 18 },
+    { col: 22, row: 13 },
+  ];
+}
+
+function greenwardEadwinBuildings(): Pos[] {
+  // Inn block (NE) — 3x3 footprint
+  const ps: Pos[] = [];
+  for (let c = 16; c <= 20; c++) {
+    for (let r = 7; r <= 9; r++) ps.push({ col: c, row: r });
+  }
+  // Shop fronts (central E-W band, sparse)
+  for (let c = 10; c <= 26; c += 4) {
+    ps.push({ col: c, row: 13 });
+    ps.push({ col: c, row: 14 });
+  }
+  return ps;
+}
+
+function greenwardEadwinRuins(): Pos[] {
+  return [
+    { col: 18, row: 10 }, // inn_hearth Mercy
+    { col: 14, row: 15 }, // village_square Siege
+  ];
+}
 
 export const MAPS: Record<MapId, MapDefinition> = {
   plains: {
@@ -895,13 +945,52 @@ export const MAPS: Record<MapId, MapDefinition> = {
   })(),
 
   // ── Campaign #3 — Greenward maps ───────────────────────────────
-  // v1: each map uses the plains-template layout for terrain shape
-  // but a distinct `theme` so the player sees different palettes
-  // mission-to-mission. Full bespoke layouts (blocked cells, multi-
-  // entry / multi-exit) land in a content polish pass.
-  greenward_boundary:     { ...MAPS_PLAINS_TEMPLATE, id: 'greenward_boundary',     name: 'Boundary Stones', theme: 'forest' },
-  greenward_meadow:       { ...MAPS_PLAINS_TEMPLATE, id: 'greenward_meadow',       name: 'Salt Meadow',     theme: 'generic' },
-  greenward_eadwin:       { ...MAPS_PLAINS_TEMPLATE, id: 'greenward_eadwin',       name: 'Eadwin',          theme: 'stone' },
+  // Act I — Border. Forest-edge wayshrine, salt meadow, inn-village.
+
+  greenward_boundary: {
+    id: 'greenward_boundary',
+    name: 'The Boundary Stones',
+    description: 'A road leaving the Wildwood at sunrise. The wayshrine waits at the road\'s end.',
+    theme: 'forest',
+    // Creeps approach from the east (the south kingdoms); they walk
+    // toward the Wildwood (west exit).
+    entries: [{ col: GRID_COLS - 1, row: MID_ROW }],
+    exits:   [{ col: 0,             row: MID_ROW }],
+    blocked: greenwardForestEdge(),
+    // Wayshrine cell — noBuild so the player can't drop a tower
+    // ON the shrine but mazes around it.
+    noBuild: [{ col: 18, row: 13 }],
+  },
+
+  greenward_meadow: {
+    id: 'greenward_meadow',
+    name: 'The Salt Meadow',
+    description: 'A meadow turned saline. Two cairns + a barrow. Open and exposed.',
+    theme: 'generic',
+    // Two entries (north + south) — Inheritors creep in from both
+    // flanks, suggesting Marra is exposed in the middle of the field.
+    entries: [
+      { col: 17, row: 0 },
+      { col: 17, row: GRID_ROWS - 1 },
+    ],
+    exits: [{ col: 0, row: MID_ROW }],
+    blocked: [], // The meadow is OPEN by design — salt killed everything.
+    noBuild: greenwardSaltCairns(),
+  },
+
+  greenward_eadwin: {
+    id: 'greenward_eadwin',
+    name: 'The Circle at Eadwin',
+    description: 'An inn-village. Hearth still burning. Strange chants in the square.',
+    theme: 'stone',
+    entries: [{ col: GRID_COLS - 1, row: MID_ROW }],
+    exits:   [{ col: 0,             row: MID_ROW }],
+    // Inn block (NE) + shop fronts in a central band create a
+    // forced weave through the village.
+    blocked: greenwardEadwinBuildings(),
+    // The inn-hearth + village square ruins are noBuild.
+    noBuild: greenwardEadwinRuins(),
+  },
   greenward_crows:        { ...MAPS_PLAINS_TEMPLATE, id: 'greenward_crows',        name: 'Road of Crows',   theme: 'water' },
   greenward_river:        { ...MAPS_PLAINS_TEMPLATE, id: 'greenward_river',        name: 'Dry River',       theme: 'water' },
   greenward_tarrenford:   { ...MAPS_PLAINS_TEMPLATE, id: 'greenward_tarrenford',   name: 'Tarrenford',      theme: 'forest' },

--- a/src/data/Maps.ts
+++ b/src/data/Maps.ts
@@ -299,6 +299,34 @@ function greenwardWeddingPavilion(): Pos[] {
   return ps;
 }
 
+function greenwardCourtGeometry(): Pos[] {
+  // Three-door courtyard: pillars + interior partitions. Each
+  // pillar cluster is between two doors so the boss-rush feels
+  // architectural, not arena.
+  const ps: Pos[] = [];
+  // Outer south wall with three door-gaps at cols 6, 18, 30.
+  for (let c = 0; c < GRID_COLS; c++) {
+    if (c !== 6 && c !== 18 && c !== 30) ps.push({ col: c, row: GRID_ROWS - 1 });
+  }
+  // Two interior pillar pairs.
+  for (let r = 8; r <= 12; r += 2) {
+    ps.push({ col: 12, row: r });
+    ps.push({ col: 24, row: r });
+  }
+  return ps;
+}
+
+function greenwardWatchtowerDefenses(): Pos[] {
+  // M9 attacker map — pre-placed defender tower positions where the
+  // mission's attacker-archetype hook drops Inheritor defenders.
+  // For map purposes these are Blocked cells (towers occupy them).
+  return [
+    { col: 8,  row: 11 },
+    { col: 10, row: 13 },
+    { col: 8,  row: 15 },
+  ];
+}
+
 export const MAPS: Record<MapId, MapDefinition> = {
   plains: {
     id: 'plains',
@@ -1122,8 +1150,43 @@ export const MAPS: Record<MapId, MapDefinition> = {
       { col: 18, row: 18 }, // pavilion (Siege)
     ],
   },
-  greenward_court:        { ...MAPS_PLAINS_TEMPLATE, id: 'greenward_court',        name: 'Stillborn Court', theme: 'stone' },
-  greenward_lastgarden:   { ...MAPS_PLAINS_TEMPLATE, id: 'greenward_lastgarden',   name: 'Last Garden',     theme: 'mountain' },
+  // Act III pre-finale — Stillborn Court + Last Garden.
+
+  greenward_court: {
+    id: 'greenward_court',
+    name: 'The Stillborn Court',
+    description: 'A courtyard with three doors. The Inheritor host enters; the Child watches.',
+    theme: 'stone',
+    // Three doors at the south edge — Knight, Herald, Child cycle.
+    entries: [
+      { col: 6,  row: GRID_ROWS - 1 },
+      { col: 18, row: GRID_ROWS - 1 },
+      { col: 30, row: GRID_ROWS - 1 },
+    ],
+    // Single north exit — leak path toward Caer Lythen.
+    exits: [{ col: MID_COL, row: 0 }],
+    blocked: greenwardCourtGeometry(),
+    // court_grounds Siege + the_child Mercy.
+    noBuild: [
+      { col: 14, row: 13 }, // court_grounds
+      { col: 22, row: 13 }, // the_child
+    ],
+  },
+
+  greenward_lastgarden: {
+    id: 'greenward_lastgarden',
+    name: 'The Last Garden',
+    description: 'An Inheritor watchtower on the road to Caer Lythen. Built of grove-wood.',
+    theme: 'mountain',
+    // Attacker mode: Marra SENDS from the east toward the watchtower
+    // at the west. Reversed entry/exit semantics — entry is where
+    // the player's creeps start (east), exit is the Inheritor
+    // territory (west) the watchtower defends.
+    entries: [{ col: GRID_COLS - 1, row: 13 }],
+    exits:   [{ col: 0,             row: 13 }],
+    blocked: greenwardWatchtowerDefenses(),
+    noBuild: [{ col: 6, row: 13 }], // watchtower
+  },
   greenward_cathedral:    { ...MAPS_PLAINS_TEMPLATE, id: 'greenward_cathedral',    name: 'Caer Lythen',     theme: 'arcane_crystal' },
 };
 

--- a/src/data/Maps.ts
+++ b/src/data/Maps.ts
@@ -327,6 +327,37 @@ function greenwardWatchtowerDefenses(): Pos[] {
   ];
 }
 
+function greenwardCathedralGeometry(): Pos[] {
+  // M10 — three-section cathedral. Dense Blocked-cell barriers
+  // separate Courtyard (cols 0-11) / Nave (cols 12-23) / Throne
+  // (cols 24-35) into three visually-distinct zones while still
+  // permitting pathfind through chokepoint gaps.
+  const ps: Pos[] = [];
+
+  // Courtyard / Nave divider — vertical wall at col 11 with a gap
+  // at the mid-row.
+  for (let r = 0; r < GRID_ROWS; r++) {
+    if (r !== MID_ROW) ps.push({ col: 11, row: r });
+  }
+  // Nave / Throne divider — vertical wall at col 24 with a gap.
+  for (let r = 0; r < GRID_ROWS; r++) {
+    if (r !== MID_ROW) ps.push({ col: 24, row: r });
+  }
+
+  // Nave pillars — four columns flanking the central nave aisle.
+  for (let r = 9; r <= 17; r += 4) {
+    ps.push({ col: 15, row: r });
+    ps.push({ col: 21, row: r });
+  }
+
+  // Throne dais — 3x3 footprint at the east end.
+  for (let c = 31; c <= 33; c++) {
+    for (let r = 12; r <= 14; r++) ps.push({ col: c, row: r });
+  }
+
+  return ps;
+}
+
 export const MAPS: Record<MapId, MapDefinition> = {
   plains: {
     id: 'plains',
@@ -1187,7 +1218,28 @@ export const MAPS: Record<MapId, MapDefinition> = {
     blocked: greenwardWatchtowerDefenses(),
     noBuild: [{ col: 6, row: 13 }], // watchtower
   },
-  greenward_cathedral:    { ...MAPS_PLAINS_TEMPLATE, id: 'greenward_cathedral',    name: 'Caer Lythen',     theme: 'arcane_crystal' },
+  // M10 — Caer Lythen, the Sun-Cathedral. Three-section setpiece
+  // map: Courtyard / Nave / Throne. Dense Blocked-cell barriers
+  // create the visual zoning while preserving pathfind through
+  // chokepoint gaps at the mid-row.
+
+  greenward_cathedral: {
+    id: 'greenward_cathedral',
+    name: 'Caer Lythen, the Sun-Cathedral',
+    description: 'Three setpieces. Courtyard, Nave, Throne. The Heron waits at the altar.',
+    theme: 'arcane_crystal',
+    // West entry (Courtyard) → east exit (Throne consequence wave).
+    entries: [{ col: 0,             row: MID_ROW }],
+    exits:   [{ col: GRID_COLS - 1, row: MID_ROW }],
+    blocked: greenwardCathedralGeometry(),
+    // Three setpiece ruins — courtyard (Siege), nave (mode resolved
+    // at runtime by GreenwardFinaleController), throne (Siege).
+    noBuild: [
+      { col: 6,  row: 13 }, // courtyard
+      { col: 18, row: 13 }, // nave
+      { col: 30, row: 13 }, // throne
+    ],
+  },
 };
 
 // (Legacy-shaped IIFE bodies removed; data lives in

--- a/src/data/maps/greenward-maps.test.ts
+++ b/src/data/maps/greenward-maps.test.ts
@@ -92,3 +92,33 @@ describe('Greenward bespoke maps — Act III pre-finale', () => {
     expect(MAPS.greenward_court.entries.length).toBe(3);
   });
 });
+
+describe('Greenward bespoke maps — M10 Caer Lythen', () => {
+  describe('M10 Caer Lythen', () => assertMapShape('greenward_cathedral', 9, 'M10 Caer Lythen'));
+
+  it('declares three setpiece ruins (Courtyard / Nave / Throne)', () => {
+    const grid = loadGreenwardMap('greenward_cathedral');
+    const expected: { col: number; row: number; id: string }[] = [
+      { col: 6,  row: 13, id: 'courtyard' },
+      { col: 18, row: 13, id: 'nave' },
+      { col: 30, row: 13, id: 'throne' },
+    ];
+    for (const r of expected) {
+      expect(grid.cells[r.row][r.col], `${r.id} should be NoBuild`).toBe(CellType.NoBuild);
+    }
+  });
+
+  it('vertical divider walls separate the three sections with mid-row gaps', () => {
+    const grid = loadGreenwardMap('greenward_cathedral');
+    // Courtyard / Nave divider at col 11 — wall above + below mid-row.
+    expect(grid.cells[0][11]).toBe(CellType.Blocked);
+    expect(grid.cells[5][11]).toBe(CellType.Blocked);
+    expect(grid.cells[20][11]).toBe(CellType.Blocked);
+    expect(grid.cells[25][11]).toBe(CellType.Blocked);
+    // Mid-row gap — pathfind threads through here.
+    expect(grid.cells[13][11]).not.toBe(CellType.Blocked);
+    // Nave / Throne divider at col 24 — same shape.
+    expect(grid.cells[0][24]).toBe(CellType.Blocked);
+    expect(grid.cells[13][24]).not.toBe(CellType.Blocked);
+  });
+});

--- a/src/data/maps/greenward-maps.test.ts
+++ b/src/data/maps/greenward-maps.test.ts
@@ -32,36 +32,48 @@ const ACT_I_MAPS: { mapId: MapId; missionIdx: number; name: string }[] = [
   { mapId: 'greenward_eadwin',   missionIdx: 2, name: 'M3 Eadwin' },
 ];
 
+const ACT_II_MAPS: { mapId: MapId; missionIdx: number; name: string }[] = [
+  { mapId: 'greenward_crows',        missionIdx: 3, name: 'M4 Road of Crows' },
+  { mapId: 'greenward_river',        missionIdx: 4, name: 'M5 Dry River' },
+  { mapId: 'greenward_tarrenford',   missionIdx: 5, name: 'M6 Tarrenford' },
+  { mapId: 'greenward_weddingstone', missionIdx: 6, name: 'M7 Wedding-Stone' },
+];
+
+function assertMapShape(mapId: MapId, missionIdx: number, name: string) {
+  it('has at least one entry + one exit', () => {
+    const def = MAPS[mapId];
+    expect(def.entries.length).toBeGreaterThanOrEqual(1);
+    expect(def.exits.length).toBeGreaterThanOrEqual(1);
+  });
+  it('every Consecration ruin cell is NoBuild (not Blocked)', () => {
+    const grid = loadGreenwardMap(mapId);
+    for (const r of ruinsFor(missionIdx)) {
+      expect(
+        grid.cells[r.row][r.col],
+        `${name} ruin "${r.id}" at (${r.col}, ${r.row}) — expected NoBuild`,
+      ).toBe(CellType.NoBuild);
+    }
+  });
+  it('pathfind from first entry to first exit succeeds', () => {
+    const grid = loadGreenwardMap(mapId);
+    const path = findPath(grid, grid.entry, grid.exit);
+    expect(path, `${name} — no path entry → exit`).not.toBeNull();
+    expect(path!.length).toBeGreaterThan(0);
+  });
+  it('description is non-empty (narrative anchor)', () => {
+    const def = MAPS[mapId];
+    expect(def.description.length).toBeGreaterThan(10);
+  });
+}
+
 describe('Greenward bespoke maps — Act I', () => {
   for (const { mapId, missionIdx, name } of ACT_I_MAPS) {
-    describe(name, () => {
-      it('has at least one entry + one exit', () => {
-        const def = MAPS[mapId];
-        expect(def.entries.length).toBeGreaterThanOrEqual(1);
-        expect(def.exits.length).toBeGreaterThanOrEqual(1);
-      });
+    describe(name, () => assertMapShape(mapId, missionIdx, name));
+  }
+});
 
-      it('every Consecration ruin cell is NoBuild (not Blocked)', () => {
-        const grid = loadGreenwardMap(mapId);
-        for (const r of ruinsFor(missionIdx)) {
-          expect(
-            grid.cells[r.row][r.col],
-            `${name} ruin "${r.id}" at (${r.col}, ${r.row}) — expected NoBuild`,
-          ).toBe(CellType.NoBuild);
-        }
-      });
-
-      it('pathfind from first entry to first exit succeeds', () => {
-        const grid = loadGreenwardMap(mapId);
-        const path = findPath(grid, grid.entry, grid.exit);
-        expect(path, `${name} — no path entry → exit`).not.toBeNull();
-        expect(path!.length).toBeGreaterThan(0);
-      });
-
-      it('description is non-empty (narrative anchor)', () => {
-        const def = MAPS[mapId];
-        expect(def.description.length).toBeGreaterThan(10);
-      });
-    });
+describe('Greenward bespoke maps — Act II', () => {
+  for (const { mapId, missionIdx, name } of ACT_II_MAPS) {
+    describe(name, () => assertMapShape(mapId, missionIdx, name));
   }
 });

--- a/src/data/maps/greenward-maps.test.ts
+++ b/src/data/maps/greenward-maps.test.ts
@@ -59,11 +59,43 @@ function assertMapShape(mapId: MapId, missionIdx: number, name: string) {
       ).toBe(CellType.NoBuild);
     }
   });
-  it('pathfind from first entry to first exit succeeds', () => {
+  it('pathfind succeeds from every entry to at least one exit', () => {
+    // Multi-entry maps (M2 / M4 / M7 / M8) must verify EACH entry
+    // reaches some exit — otherwise a misplaced Blocked cluster
+    // could orphan a spawner without the test catching it. We don't
+    // require every entry → every exit combo: spawners pick the
+    // shortest path each, so "at least one exit reachable per entry"
+    // is the gameplay contract.
     const grid = loadGreenwardMap(mapId);
-    const path = findPath(grid, grid.entry, grid.exit);
-    expect(path, `${name} — no path entry → exit`).not.toBeNull();
-    expect(path!.length).toBeGreaterThan(0);
+    for (const entry of grid.entries) {
+      let reached = false;
+      for (const exit of grid.exits) {
+        const path = findPath(grid, entry, exit);
+        if (path && path.length > 0) { reached = true; break; }
+      }
+      expect(
+        reached,
+        `${name} entry (${entry.col}, ${entry.row}) — no path to any exit`,
+      ).toBe(true);
+    }
+  });
+
+  it('pathfind succeeds from at least one entry to every exit', () => {
+    // The reverse direction — every exit must be reachable from
+    // SOME entry. Catches the rarer case where an entry-only-reachable
+    // exit gets walled off but the entries still see another exit.
+    const grid = loadGreenwardMap(mapId);
+    for (const exit of grid.exits) {
+      let reached = false;
+      for (const entry of grid.entries) {
+        const path = findPath(grid, entry, exit);
+        if (path && path.length > 0) { reached = true; break; }
+      }
+      expect(
+        reached,
+        `${name} exit (${exit.col}, ${exit.row}) — no entry reaches it`,
+      ).toBe(true);
+    }
   });
   it('description is non-empty (narrative anchor)', () => {
     const def = MAPS[mapId];

--- a/src/data/maps/greenward-maps.test.ts
+++ b/src/data/maps/greenward-maps.test.ts
@@ -39,6 +39,11 @@ const ACT_II_MAPS: { mapId: MapId; missionIdx: number; name: string }[] = [
   { mapId: 'greenward_weddingstone', missionIdx: 6, name: 'M7 Wedding-Stone' },
 ];
 
+const ACT_III_PRE_FINALE_MAPS: { mapId: MapId; missionIdx: number; name: string }[] = [
+  { mapId: 'greenward_court',      missionIdx: 7, name: 'M8 Stillborn Court' },
+  { mapId: 'greenward_lastgarden', missionIdx: 8, name: 'M9 Last Garden' },
+];
+
 function assertMapShape(mapId: MapId, missionIdx: number, name: string) {
   it('has at least one entry + one exit', () => {
     const def = MAPS[mapId];
@@ -76,4 +81,14 @@ describe('Greenward bespoke maps — Act II', () => {
   for (const { mapId, missionIdx, name } of ACT_II_MAPS) {
     describe(name, () => assertMapShape(mapId, missionIdx, name));
   }
+});
+
+describe('Greenward bespoke maps — Act III pre-finale', () => {
+  for (const { mapId, missionIdx, name } of ACT_III_PRE_FINALE_MAPS) {
+    describe(name, () => assertMapShape(mapId, missionIdx, name));
+  }
+
+  it('M8 declares three entries (Stillborn Court three doors)', () => {
+    expect(MAPS.greenward_court.entries.length).toBe(3);
+  });
 });

--- a/src/data/maps/greenward-maps.test.ts
+++ b/src/data/maps/greenward-maps.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Greenward bespoke map shape tests. Per the bespoke-maps PRD,
+ * each Greenward map must:
+ *   - declare entries + exits
+ *   - mark its Consecration ruin cells as NoBuild (not Blocked)
+ *   - support pathfind from at least one entry to at least one exit
+ *     (no map-shape regression where a Blocked cluster severs the path)
+ *
+ * Each act gets its own describe block; per-mission cells reference
+ * the Consecration ruin coords declared in greenward.ts.
+ */
+import { describe, it, expect } from 'vitest';
+import { MAPS, type MapId } from '../Maps';
+import { GREENWARD_CAMPAIGN } from '../campaigns/greenward';
+import { Grid, CellType } from '../../systems/Grid';
+import { findPath } from '../../systems/Pathfinding';
+
+function loadGreenwardMap(id: MapId): Grid {
+  const def = MAPS[id];
+  if (!def) throw new Error(`map ${id} not in MAPS`);
+  return new Grid(def);
+}
+
+function ruinsFor(missionIdx: number): { col: number; row: number; id: string }[] {
+  const m = GREENWARD_CAMPAIGN.missions[missionIdx];
+  return (m?.overrides.greenwardRules?.ruins ?? []).map(r => ({ col: r.col, row: r.row, id: r.id }));
+}
+
+const ACT_I_MAPS: { mapId: MapId; missionIdx: number; name: string }[] = [
+  { mapId: 'greenward_boundary', missionIdx: 0, name: 'M1 Boundary Stones' },
+  { mapId: 'greenward_meadow',   missionIdx: 1, name: 'M2 Salt Meadow' },
+  { mapId: 'greenward_eadwin',   missionIdx: 2, name: 'M3 Eadwin' },
+];
+
+describe('Greenward bespoke maps — Act I', () => {
+  for (const { mapId, missionIdx, name } of ACT_I_MAPS) {
+    describe(name, () => {
+      it('has at least one entry + one exit', () => {
+        const def = MAPS[mapId];
+        expect(def.entries.length).toBeGreaterThanOrEqual(1);
+        expect(def.exits.length).toBeGreaterThanOrEqual(1);
+      });
+
+      it('every Consecration ruin cell is NoBuild (not Blocked)', () => {
+        const grid = loadGreenwardMap(mapId);
+        for (const r of ruinsFor(missionIdx)) {
+          expect(
+            grid.cells[r.row][r.col],
+            `${name} ruin "${r.id}" at (${r.col}, ${r.row}) — expected NoBuild`,
+          ).toBe(CellType.NoBuild);
+        }
+      });
+
+      it('pathfind from first entry to first exit succeeds', () => {
+        const grid = loadGreenwardMap(mapId);
+        const path = findPath(grid, grid.entry, grid.exit);
+        expect(path, `${name} — no path entry → exit`).not.toBeNull();
+        expect(path!.length).toBeGreaterThan(0);
+      });
+
+      it('description is non-empty (narrative anchor)', () => {
+        const def = MAPS[mapId];
+        expect(def.description.length).toBeGreaterThan(10);
+      });
+    });
+  }
+});


### PR DESCRIPTION
Plan for replacing the theme-overridden plains-template stubs from PR #74 with hand-authored maps per mission. Each map is authored via /editor.html and exported as JSON saved to src/data/maps/greenward/.

Per-map design guidelines covering reads-as (narrative beat), entries / exits, ruin cell placement, blocked cells, and effort estimate. Batched by Act for review tractability:

  Commit 1 — Act I (M1-M3): Boundary Stones / Salt Meadow / Eadwin
  Commit 2 — Act II (M4-M7): Road of Crows / Dry River / Tarrenford
                             / Wedding-Stone
  Commit 3 — Act III pre-finale (M8-M9): Stillborn Court / Last Garden
  Commit 4 — M10 Caer Lythen three-section cathedral

Per-map deliverables: JSON file + Maps.ts integration + unit test asserting entries/exits/ruin-NoBuild + pathfind succeeds.

Effort: ~10-12 hrs end-to-end (heavily front-loaded on the editor, not engineering).